### PR TITLE
fix: Correct typo 'initialLoading' in loading state variable

### DIFF
--- a/webui/src/components/LatestValue.tsx
+++ b/webui/src/components/LatestValue.tsx
@@ -5,7 +5,7 @@ import { ConfigValue } from '../types';
 type LatestValueProps = ConfigValue & LatestValueQueryParams
 
 const LatestValue: React.FC<LatestValueProps> = (props) => {
-  const { initalLoading, loading, error, result } = useLatestValueQuery(props);
+  const { initialLoading, loading, error, result } = useLatestValueQuery(props);
   const { decimals = 1, title, field, unit } = props;
   const value: number = result.length > 0 ? result[0]._value : null;
 
@@ -13,7 +13,7 @@ const LatestValue: React.FC<LatestValueProps> = (props) => {
     <div className="p-4 rounded-lg bg-blue-100 dark:bg-blue-900 shadow flex flex-col items-center justify-center h-full">
       <h2 className="text-lg md:text-xl font-semibold mb-2">{title || field}</h2>
       <div className="text-5xl md:text-6xl font-bold">
-        {initalLoading ? (
+        {initialLoading ? (
           <>...</>
         ) : (
           <div className={

--- a/webui/src/hooks/useFluxQuery.ts
+++ b/webui/src/hooks/useFluxQuery.ts
@@ -8,7 +8,7 @@ function useFluxQuery({ fluxQuery, reloadInterval = queryReloadInterval }: { flu
   const org = 'home';
 
   const [loading, setLoading] = useState(true);
-  const [initalLoading, setInitalLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [result, setResult] = useState<any[]>([]);
 
@@ -39,7 +39,7 @@ function useFluxQuery({ fluxQuery, reloadInterval = queryReloadInterval }: { flu
           if (!cancelled) {
             setResult(rows);
             setLoading(false)
-            setInitalLoading(false);
+            setInitialLoading(false);
           }
         }
       });
@@ -59,7 +59,7 @@ function useFluxQuery({ fluxQuery, reloadInterval = queryReloadInterval }: { flu
     };
   }, [fluxQuery]);
 
-  return { initalLoading, loading, error, result };
+  return { initialLoading, loading, error, result };
 }
 
 export default useFluxQuery;


### PR DESCRIPTION
This PR fixes a typo where the loading state variable was misspelled as 'initalLoading'. It corrects the variable name to 'initialLoading' in the useFluxQuery hook and all relevant component usage. This improves code readability and type safety without any functional changes.