### PR TITLE
fix: only append points with valid fields to prevent InfluxDB batch rejection

### DIFF
--- a/python/src/aquatemp.py
+++ b/python/src/aquatemp.py
@@ -139,13 +139,19 @@ def _aquatemp():
             .tag('device_id', device['deviceId'])\
             .tag('device_model', device['custModel'])
 
+        has_fields = False
         for deviceDataObject in deviceData:
             metricName = CODES.get(
                 deviceDataObject['code'], 'unknown_' + deviceDataObject['code'])
-            if deviceDataObject['value']:
+            if deviceDataObject.get('value'):
                 p = p.field(metricName, float(deviceDataObject['value']))
+                has_fields = True
             else:
                 logging.warning(f"Device {deviceCode} has no value for {metricName}, skipping.")
-        points.append(p)
+        
+        if has_fields:
+            points.append(p)
+        else:
+            logging.warning(f"Device {deviceCode} has no valid data points, skipping influx write for this device.")
 
     write_influx(points)


### PR DESCRIPTION
Addresses the high-priority comment from PR #35.

The previous fix correctly handled missing values but introduced a logical flaw where Points with no fields could be created and sent to InfluxDB, causing the entire batch to be rejected.

This fix:
- Tracks whether any fields were successfully added to a Point using a `has_fields` flag
- Only appends Points to the batch if they contain at least one valid field
- Adds appropriate warning logging when a device has no valid data points
- Uses `.get('value')` instead of `['value']` for safer access to the value field

This prevents InfluxDB batch rejections while maintaining proper error handling for missing device data.

Fixes the issue identified in: https://github.com/tkhduracell/iot-fetcher/pull/35#discussion_r2239024911