### PR TITLE
feat: add module-specific loggers with [module] prefix formatting

### DIFF
--- a/python/src/airquality.py
+++ b/python/src/airquality.py
@@ -4,6 +4,9 @@ import os
 
 from influx import write_influx, Point, WritePrecision
 
+# Configure module-specific logger
+logger = logging.getLogger(__name__)
+
 BASE_URL = "https://airquality.googleapis.com/v1/currentConditions"
 
 GOOGLE_API_KEY = os.environ['GOOGLE_API_KEY']
@@ -14,14 +17,14 @@ def airquality():
     try:
         _airquality()
     except Exception as e:
-        logging.exception(f"Failed to execute airquality module: {e}")
+        logger.exception(f"[airquality] Failed to execute airquality module: {e}")
 
 
 def _airquality():
-    logging.info("Fetching air quality data from Google API...")
+    logger.info("[airquality] Fetching air quality data from Google API...")
 
     url = f"{BASE_URL}:lookup?key={GOOGLE_API_KEY}"
-    logging.info(f"Fetching air quality data from {url}...")
+    logger.info(f"[airquality] Fetching air quality data from {url}...")
 
     try:
         [lat, lng] = GOOGLE_LAT_LNG.split(',')
@@ -37,12 +40,12 @@ def _airquality():
             ]
         })
     except requests.exceptions.RequestException as e:
-        logging.error(f"Error making API request: {e}")
+        logger.error(f"[airquality] Error making API request: {e}")
         return
 
     if resp.status_code != 200:
-        logging.error(
-            f"Error when fetching air quality data: {
+        logger.error(
+            f"[airquality] Error when fetching air quality data: {
                 resp.status_code} - {resp.text}"
         )
         return

--- a/python/src/aqualink.py
+++ b/python/src/aqualink.py
@@ -16,6 +16,9 @@ from iaqualink.const import (
 
 from influx import write_influx, Point
 
+# Configure module-specific logger
+logger = logging.getLogger(__name__)
+
 aqualink_username = os.environ['AQUALINK_USERNAME'] or ''
 aqualink_password = os.environ['AQUALINK_PASSWORD'] or ''
 
@@ -24,11 +27,11 @@ def aqualink():
     try:
         asyncio.run(_aqualink())
     except:
-        logging.warning("Failed to run aqualink module", exc_info=True)
+        logger.warning("[aqualink] Failed to run aqualink module", exc_info=True)
 
 
 async def _aqualink():
-    logging.info("Fetching Aqualink data...")
+    logger.info("[aqualink] Fetching Aqualink data...")
 
     async with AqualinkClient(aqualink_username, aqualink_password) as c:
         points: List[Point] = []

--- a/python/src/balboa.py
+++ b/python/src/balboa.py
@@ -10,6 +10,9 @@ from influxdb_client import Point
 
 from influx import write_influx
 
+# Configure module-specific logger
+logger = logging.getLogger(__name__)
+
 # Balboa configuration
 spa_ip = os.environ['BALBOA_HOST'] or '192.168.68.53'
 
@@ -20,26 +23,26 @@ def balboa():
     except KeyboardInterrupt:
         pass
     except pybalboa.exceptions.SpaConnectionError:
-        logging.info("Unable to connect to balboa spa...")
+        logger.info("[balboa] Unable to connect to balboa spa...")
     except Exception:
-        logging.warning("Unexpected error in balboa spa")
+        logger.warning("[balboa] Unexpected error in balboa spa")
 
 
 async def _balboa():
-    logging.info("Connecting to Balboa Spa at IP address " +
+    logger.info("[balboa] Connecting to Balboa Spa at IP address " +
                  spa_ip)
     async with pybalboa.SpaClient(spa_ip) as spa:
         await spa.connect()
 
         # wait for the spa to be ready for use
         while not spa.available:
-            logging.info("Waiting for spa to be ready...")
+            logger.info("[balboa] Waiting for spa to be ready...")
             await asyncio.sleep(5)
 
         # read/run spa commands
         if not spa.connected:
             spa.disconnect()
-            logging.info(f'Not connected to spa. Reconnecting in 30 sec (available: {
+            logger.info(f'[balboa] Not connected to spa. Reconnecting in 30 sec (available: {
                 spa.available}, connected: {spa.connected})')
             return
 
@@ -54,8 +57,8 @@ async def _balboa():
         if type(temperature) is float or type(temperature) is int:
             temp = temp.field("value", temperature)
         else:
-            logging.info(
-                'Temperature reading failed. Discarding temp data...')
+            logger.info(
+                '[balboa] Temperature reading failed. Discarding temp data...')
 
         heat = Point("spa_mode") \
             .field("enabled", spa.heat_mode.state)
@@ -63,7 +66,7 @@ async def _balboa():
         circ = Point("spa_circulation_pump") \
             .field("enabled", spa.circulation_pump.state)
 
-        logging.info("Disconnecting from spa")
+        logger.info("[balboa] Disconnecting from spa")
         await spa.disconnect()
 
         write_influx([temp, heat, circ])

--- a/python/src/elpris.py
+++ b/python/src/elpris.py
@@ -5,6 +5,9 @@ import requests
 
 from influx import write_influx, Point, WritePrecision
 
+# Configure module-specific logger
+logger = logging.getLogger(__name__)
+
 areas = ["SE4"]
 
 
@@ -29,20 +32,20 @@ def elpris():
     try:
         _elpris()
     except:
-        logging.exception("Failed to execute elpris module")
+        logger.exception("[elpris] Failed to execute elpris module")
 
 
 def _elpris():
-    logging.info("Fetching energy prices from Elpriset justnu...")
+    logger.info("[elpris] Fetching energy prices from Elpriset justnu...")
 
     for area in areas:
         for i in range(-7, 1):
             url = get_elpris_price_url(area=area, day_offset=i)
-            logging.info(f"Fetching energy prices from {url}...")
+            logger.info(f"[elpris] Fetching energy prices from {url}...")
             resp = requests.get(url)
 
             if (resp.status_code != 200):
-                logging.info("Error when fetching energy prices: " + str(resp))
+                logger.info("[elpris] Error when fetching energy prices: " + str(resp))
                 continue
 
             json: List[dict] = resp.json()

--- a/python/src/ngenic.py
+++ b/python/src/ngenic.py
@@ -10,6 +10,9 @@ from ngenicpy.models.measurement import Measurement, MeasurementType
 
 from influx import write_influx, Point
 
+# Configure module-specific logger
+logger = logging.getLogger(__name__)
+
 ngenic_token = os.environ['NGENIC_TOKEN'] or ''
 
 logging.getLogger("httpx").setLevel(level=logging.WARNING)
@@ -19,17 +22,17 @@ def ngenic():
     try:
         _ngenic()
     except:
-        logging.exception("Failed to execute ngenice module")
+        logger.exception("[ngenic] Failed to execute ngenice module")
 
 
 def _ngenic():
-    logging.info("Fetching Ngenic data...")
+    logger.info("[ngenic] Fetching Ngenic data...")
     with Ngenic(token=ngenic_token) as ngenic:
 
         tunes = ngenic.tunes()
 
         for tune in tunes:
-            logging.debug("Tune %s, Name: %s, Tune Name: %s" %
+            logger.debug("[ngenic] Tune %s, Name: %s, Tune Name: %s" %
                          (
                              tune.uuid(),
                              tune["name"],
@@ -41,7 +44,7 @@ def _ngenic():
 
         rooms = tune.rooms()
         for room in rooms:
-            logging.debug("Room %s, Name: %s, Target Temperature: %d" %
+            logger.debug("[ngenic] Room %s, Name: %s, Target Temperature: %d" %
                          (
                              room.uuid(),
                              room["name"],
@@ -53,7 +56,7 @@ def _ngenic():
         points: List[Point] = []
 
         for node in nodes:
-            logging.debug("Node %s, Type: %s, Mesurements: %s" %
+            logger.debug("[ngenic] Node %s, Type: %s, Mesurements: %s" %
                          (
                              node.uuid(),
                              node.get_type().name,


### PR DESCRIPTION
This PR adds module-specific loggers to all scheduled modules for improved debugging and log organization.

## Changes Made

- Added `logger = logging.getLogger(__name__)` to each module
- Updated all logging calls to use consistent `[module]` prefix format
- Improved log readability and module identification

## Modules Updated

- `balboa.py`: Uses `[balboa]` prefix
- `elpris.py`: Uses `[elpris]` prefix  
- `ngenic.py`: Uses `[ngenic]` prefix
- `aqualink.py`: Uses `[aqualink]` prefix
- `aquatemp.py`: Uses `[aquatemp]` prefix
- `airquality.py`: Uses `[airquality]` prefix

## Benefits

- Clear module identification in logs
- Easier debugging and filtering
- Consistent logging format across all modules
- Better monitoring and troubleshooting capabilities

Example log output:
```
INFO [balboa] Connecting to Balboa Spa at IP address 192.168.68.53
INFO [aquatemp] Fetching Aquatemp device list...
INFO [airquality] Fetching air quality data from Google API...
```