### PR TITLE
feat: reduce Signergy polling interval to 1 minute

### DIFF
--- a/python/src/main.py
+++ b/python/src/main.py
@@ -32,11 +32,11 @@ def main():
                 logging.info(f"Executing {module_name} module...")
                 m()
         return
-    
+
     logging.info("Starting the scheduler...")
     schedule.every(5).minutes.do(aqualink)
     schedule.every(5).minutes.do(ngenic)
-    schedule.every(5).minutes.do(sigenergy)
+    schedule.every(1).minutes.do(sigenergy)
     schedule.every(5).minutes.do(balboa)
     schedule.every(5).minutes.do(aquatemp)
 


### PR DESCRIPTION
This PR reduces the Signergy polling interval from 5 minutes to 1 minute to get more frequent data updates.

## Changes
- Updated `schedule.every(5).minutes.do(sigenergy)` to `schedule.every(1).minutes.do(sigenergy)` in `python/src/main.py`

## Impact
- Signergy data will now be fetched every minute instead of every 5 minutes
- More frequent data collection for better monitoring granularity