### PR TITLE
fix: update Caddy proxy configuration for /upload route

### DIFF
--- a/influx-proxy/Dockerfile
+++ b/influx-proxy/Dockerfile
@@ -33,7 +33,7 @@ cat > /etc/caddy/Caddyfile <<'CADDYFILE'
 		header_up X-Forwarded-Proto {scheme}
 	}
 
-	reverse_proxy /upload/* {$API_TARGET} {
+	reverse_proxy /upload /upload/* {$API_TARGET} {
 		header_up Host {host}
 		header_up X-Forwarded-For {remote}
 		header_up X-Forwarded-Proto {scheme}


### PR DESCRIPTION
## Summary
- Update Caddy proxy configuration to handle both `/upload` and `/upload/*` routes
- Fixes routing issue where requests to the exact `/upload` path were not being proxied

## Changes
- Modified `reverse_proxy` directive in Dockerfile to include both `/upload` and `/upload/*` patterns
- This ensures proper routing for all upload-related requests to the API target

## Test plan
- [ ] Verify `/upload` endpoint responds correctly
- [ ] Verify `/upload/*` sub-paths continue to work as expected
- [ ] Test upload functionality through the proxy

🤖 Generated with [Claude Code](https://claude.ai/code)