### PR TITLE
fix: include push proto files in copy:proto script

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -14,7 +14,7 @@
     "dev": "node --experimental-strip-types --env-file ../.env --watch index.mts",
     "build": "esbuild index.mts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js --external:bufferutil --external:utf-8-validate && npm run copy:proto",
     "start": "node dist/index.js",
-    "copy:proto": "mkdir -p dist/proto && cp node_modules/eufy-security-client/build/mqtt/proto/* dist/proto/"
+    "copy:proto": "mkdir -p dist/proto && cp node_modules/eufy-security-client/build/mqtt/proto/* node_modules/eufy-security-client/build/push/proto/* dist/proto/"
   },
   "dependencies": {
     "@influxdata/influxdb-client": "^1.35.0",


### PR DESCRIPTION
## Summary
- Updates the `copy:proto` npm script to include push protocol files in addition to MQTT protocol files
- Ensures both `node_modules/eufy-security-client/build/mqtt/proto/*` and `node_modules/eufy-security-client/build/push/proto/*` are copied to `dist/proto/`

## Test plan
- [ ] Verify the build process copies both MQTT and push protocol files
- [ ] Ensure the application functions correctly with both protocol types available

🤖 Generated with [Claude Code](https://claude.ai/code)