### PR TITLE
Validate UUID in upload route and return appropriate response

### DIFF
--- a/webui/web.py
+++ b/webui/web.py
@@ -85,7 +85,12 @@ def upload():
 
 @app.route('/upload/<uuid>', methods=['GET', 'HEAD'])
 def uploads(uuid: str):
-    return send_from_directory(upload_folder, uuid)
+    # validate uuid
+    uuid4 = uuid.UUID(uuid)
+    if str(uuid4) != uuid:
+        return make_response('Invalid upload id', 400)
+
+    return send_file(os.path.join(upload_folder, uuid), as_attachment=True)
 
 
 @app.route('/metrics/<device>', methods=['GET', 'HEAD'])


### PR DESCRIPTION
Implement UUID validation in the upload route to ensure the provided UUID is valid, returning a 400 error for invalid UUIDs.