### PR TITLE
Add Sonos widget with real-time controls

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -7,6 +7,7 @@ import useAutoReload from './hooks/useAutoReload';
 import LatestValueFullscreen from './components/LatestValueFullscreen';
 import { values } from './values';
 import EnergyPriceBar from './components/EnergyPriceBar';
+import SonosWidget from './components/SonosWidget';
 import { Config, ConfigRow } from './types';
 
 
@@ -31,7 +32,7 @@ function useFullscreenParams(values: Config) {
 const Row: React.FC<{row: ConfigRow; rowIdx: number; onOpen: (row: number, col: number) => void;}> = ({ row, rowIdx, onOpen }) => (
   <div className="flex flex-row gap-1 min-h-[13.8vh]">
     {row.map((item, colIdx) => (
-      <div className="flex-1 cursor-pointer" key={`${item.measurement}-${item.field}`} onClick={() => onOpen(rowIdx, colIdx)}>
+      <div className="flex-1 cursor-pointer" key={`${item.measurement}-${item.field}-${item.filter ? JSON.stringify(item.filter) : ''}`} onClick={() => onOpen(rowIdx, colIdx)}>
         <LatestValue {...item} />
       </div>
     ))}
@@ -61,7 +62,8 @@ const AppContent: React.FC = () => {
             </div>
             <div className="w-full py-0 flex flex-col gap-1.5">
                 <Grid values={values} onOpen={openFullscreen} />
-                <EnergyPriceBar />
+                {!fullscreenProps && <EnergyPriceBar />}
+                {!fullscreenProps && <SonosWidget />}
             </div>
             { fullscreenProps && <LatestValueFullscreen 
                 open={!!fullscreenProps}

--- a/webui/src/components/SonosWidget.tsx
+++ b/webui/src/components/SonosWidget.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import useSonosQuery from '../hooks/useSonosQuery';
+import { SonosZone } from '../types';
+
+type SonosZoneCardProps = {
+  zone: SonosZone;
+  onPlayPause: (roomName: string, action: 'play' | 'pause') => void;
+  onNext: (roomName: string) => void;
+  onMuteToggle: (zoneUuid: string, roomName: string, action: 'mute' | 'unmute') => void;
+  onVolumeChange: (roomName: string, change: number) => void;
+};
+
+const SonosZoneCard: React.FC<SonosZoneCardProps> = ({ zone, onPlayPause, onNext, onMuteToggle, onVolumeChange }) => {
+  const { coordinator } = zone;
+  const { roomName, state } = coordinator;
+  const { currentTrack, playbackState } = state;
+  
+  const isPlaying = playbackState === 'PLAYING';
+  const isMuted = state.mute;
+  const trackInfo = currentTrack.artist && currentTrack.title 
+    ? `${currentTrack.artist} - ${currentTrack.title}`
+    : currentTrack.title || 'No track info';
+
+  const handlePlayPause = () => {
+    const action = isPlaying ? 'pause' : 'play';
+    onPlayPause(roomName, action);
+  };
+
+  const handleNext = () => {
+    onNext(roomName);
+  };
+
+  const handleMuteToggle = () => {
+    const action = isMuted ? 'unmute' : 'mute';
+    onMuteToggle(zone.uuid, roomName, action);
+  };
+
+  const handleVolumeDown = () => {
+    onVolumeChange(roomName, -5);
+  };
+
+  const handleVolumeUp = () => {
+    onVolumeChange(roomName, 5);
+  };
+
+  return (
+    <div className="flex-1 min-w-[200px] bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center gap-3">
+        {currentTrack.absoluteAlbumArtUri && (
+          <img 
+            src={currentTrack.absoluteAlbumArtUri} 
+            alt={currentTrack.album}
+            className="w-12 h-12 rounded object-cover flex-shrink-0"
+          />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm text-gray-900 dark:text-gray-100 mb-1">
+            {roomName}
+          </div>
+          <div className="text-xs text-gray-600 dark:text-gray-400 truncate">
+            {trackInfo}
+          </div>
+        </div>
+        <div className="flex gap-1 items-center">
+          <button
+            onClick={handlePlayPause}
+            className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white flex items-center justify-center transition-colors"
+            title={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? (
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M6 4h2v12H6V4zm6 0h2v12h-2V4z"/>
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M6.5 5.5v9l7-4.5-7-4.5z"/>
+              </svg>
+            )}
+          </button>
+          
+          <button
+            onClick={handleNext}
+            className="flex-shrink-0 w-10 h-10 rounded-full bg-gray-500 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-700 text-white flex items-center justify-center transition-colors"
+            title="Next track"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798L4.555 5.168z"/>
+            </svg>
+          </button>
+          
+          <button
+            onClick={handleVolumeDown}
+            className="flex-shrink-0 w-8 h-8 rounded-full bg-green-500 hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700 text-white flex items-center justify-center transition-colors"
+            title="Volume Down (-5)"
+          >
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z"/>
+            </svg>
+          </button>
+
+          <button
+            onClick={handleMuteToggle}
+            className={`flex-shrink-0 w-10 h-10 rounded-full text-white flex items-center justify-center transition-colors ${
+              isMuted 
+                ? 'bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700' 
+                : 'bg-green-500 hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700'
+            }`}
+            title={isMuted ? 'Unmute' : 'Mute'}
+          >
+            {isMuted ? (
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.617.787L4.7 13.04H2a1 1 0 01-1-1V8a1 1 0 011-1h2.7l3.683-3.747a1 1 0 011.617.787zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 11-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clipRule="evenodd"/>
+                <path d="M3 3l14 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.617.787L4.7 13.04H2a1 1 0 01-1-1V8a1 1 0 011-1h2.7l3.683-3.747a1 1 0 011.617.787zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 11-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clipRule="evenodd"/>
+              </svg>
+            )}
+          </button>
+
+          <button
+            onClick={handleVolumeUp}
+            className="flex-shrink-0 w-8 h-8 rounded-full bg-green-500 hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700 text-white flex items-center justify-center transition-colors"
+            title="Volume Up (+5)"
+          >
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SonosWidget: React.FC = () => {
+  const { initialLoading, error, result, updateZoneMute } = useSonosQuery();
+
+  const handlePlayPause = async (roomName: string, action: 'play' | 'pause') => {
+    try {
+      const response = await fetch(`/sonos/${encodeURIComponent(roomName)}/${action}`);
+      if (!response.ok) {
+        console.error(`Failed to ${action} ${roomName}`);
+      }
+    } catch (err) {
+      console.error(`Error ${action}ing ${roomName}:`, err);
+    }
+  };
+
+  const handleNext = async (roomName: string) => {
+    try {
+      const response = await fetch(`/sonos/${encodeURIComponent(roomName)}/next`);
+      if (!response.ok) {
+        console.error(`Failed to skip to next track for ${roomName}`);
+      }
+    } catch (err) {
+      console.error(`Error skipping to next track for ${roomName}:`, err);
+    }
+  };
+
+  const handleMuteToggle = async (zoneUuid: string, roomName: string, action: 'mute' | 'unmute') => {
+    // Optimistically update UI first
+    const newMutedState = action === 'mute';
+    updateZoneMute(zoneUuid, newMutedState);
+    
+    try {
+      const response = await fetch(`/sonos/${encodeURIComponent(roomName)}/${action}`);
+      if (!response.ok) {
+        // Revert on error
+        updateZoneMute(zoneUuid, !newMutedState);
+        console.error(`Failed to ${action} ${roomName}`);
+      }
+    } catch (err) {
+      // Revert on error
+      updateZoneMute(zoneUuid, !newMutedState);
+      console.error(`Error ${action}ing ${roomName}:`, err);
+    }
+  };
+
+  const handleVolumeChange = async (roomName: string, change: number) => {
+    try {
+      const changeStr = change > 0 ? `+${change}` : `${change}`;
+      const response = await fetch(`/sonos/${encodeURIComponent(roomName)}/volume/${changeStr}`);
+      if (!response.ok) {
+        console.error(`Failed to change volume by ${change} for ${roomName}`);
+      }
+    } catch (err) {
+      console.error(`Error changing volume by ${change} for ${roomName}:`, err);
+    }
+  };
+
+  if (initialLoading && !error) {
+    return (
+      <div className="w-full flex justify-center">
+        <div className="text-sm text-gray-600 dark:text-gray-300">
+          Laddar Sonos-zoner...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full flex justify-center">
+        <div className="text-sm text-red-600 dark:text-red-400">
+          Fel vid laddning av Sonos: {error.message}
+        </div>
+      </div>
+    );
+  }
+
+  const playingZones = result.filter(zone => zone.coordinator.state.playbackState === 'PLAYING');
+
+  if (playingZones.length === 0) {
+    return (
+      <div className="w-full flex justify-center">
+        <div className="text-sm text-gray-600 dark:text-gray-300">
+          Inga zoner spelar just nu
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full flex justify-center">
+      <div className="max-w-[50vw] w-full">
+        <div className="flex gap-2 flex-wrap justify-center">
+          {playingZones.map(zone => (
+            <SonosZoneCard 
+              key={zone.uuid} 
+              zone={zone} 
+              onPlayPause={handlePlayPause}
+              onNext={handleNext}
+              onMuteToggle={handleMuteToggle}
+              onVolumeChange={handleVolumeChange}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SonosWidget;

--- a/webui/src/hooks/useSonosQuery.ts
+++ b/webui/src/hooks/useSonosQuery.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { queryReloadInterval, queryJitterInterval } from '../globals';
+import { SonosZone } from '../types';
+
+type UseSonosQueryResult = {
+  initialLoading: boolean;
+  loading: boolean;
+  error: Error | null;
+  result: SonosZone[];
+};
+
+const useSonosQuery = (): UseSonosQueryResult & { 
+  updateZoneMute: (zoneUuid: string, muted: boolean) => void;
+} => {
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [result, setResult] = useState<SonosZone[]>([]);
+
+  const updateZoneMute = (zoneUuid: string, muted: boolean) => {
+    setResult(prevResult => 
+      prevResult.map(zone => 
+        zone.uuid === zoneUuid
+          ? {
+              ...zone,
+              coordinator: {
+                ...zone.coordinator,
+                state: {
+                  ...zone.coordinator.state,
+                  mute: muted
+                }
+              },
+              members: zone.members.map(member => 
+                member.uuid === zoneUuid
+                  ? {
+                      ...member,
+                      state: {
+                        ...member.state,
+                        mute: muted
+                      }
+                    }
+                  : member
+              )
+            }
+          : zone
+      )
+    );
+  };
+
+  const fetchSonosZones = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch('/sonos/zones');
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      
+      const data: SonosZone[] = await response.json();
+      setResult(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setLoading(false);
+      setInitialLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSonosZones();
+
+    const jitter = Math.random() * queryJitterInterval;
+    const interval = setInterval(() => {
+      fetchSonosZones();
+    }, 5000 + jitter);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return {
+    initialLoading,
+    loading,
+    error,
+    result,
+    updateZoneMute,
+  };
+};
+
+export default useSonosQuery;

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -12,3 +12,68 @@ export type ConfigValue = {
   decimals?: number;
   reload?: number;
 };
+
+// Sonos types based on API response
+export type SonosZone = {
+  uuid: string;
+  coordinator: SonosCoordinator;
+  members: SonosMember[];
+};
+
+export type SonosCoordinator = {
+  uuid: string;
+  state: SonosState;
+  roomName: string;
+  coordinator: string;
+  groupState: {
+    volume: number;
+    mute: boolean;
+  };
+};
+
+export type SonosMember = {
+  uuid: string;
+  state: SonosState;
+  roomName: string;
+  coordinator: string;
+  groupState: {
+    volume: number;
+    mute: boolean;
+  };
+};
+
+export type SonosState = {
+  volume: number;
+  mute: boolean;
+  equalizer: {
+    bass: number;
+    treble: number;
+    loudness: boolean;
+    speechEnhancement?: boolean;
+    nightMode?: boolean;
+  };
+  currentTrack: SonosTrack;
+  nextTrack: SonosTrack;
+  trackNo: number;
+  elapsedTime: number;
+  elapsedTimeFormatted: string;
+  playbackState: "PLAYING" | "PAUSED_PLAYBACK" | "STOPPED";
+  playMode: {
+    repeat: string;
+    shuffle: boolean;
+    crossfade: boolean;
+  };
+};
+
+export type SonosTrack = {
+  artist: string;
+  title: string;
+  album: string;
+  albumArtUri: string;
+  duration: number;
+  uri: string;
+  trackUri?: string;
+  type?: string;
+  stationName?: string;
+  absoluteAlbumArtUri?: string;
+};

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -16,18 +16,9 @@ function influxProxy(): Plugin {
         createProxyMiddleware({
           target: `http://${process.env.INFLUX_HOST}`,
           changeOrigin: true,
-          pathRewrite: { 
-            '^/query': '/api/v2/query',
-          },
-          pathFilter: 
-          [
-            '/query', 
-            '/health'
-          ],
-          logger: {
-            error: console.error,
-            info: console.info
-          },
+          pathRewrite: { '^/query': '/api/v2/query' },
+          pathFilter: [ '/query', '/health' ],
+          logger: { error: console.error, info: console.info },
           on: {
             proxyReq: (proxyReq) => {
               if (process.env.INFLUX_TOKEN) {
@@ -37,7 +28,17 @@ function influxProxy(): Plugin {
           }
         })
       );
+      server.middlewares.use(
+        '/sonos/',
+        createProxyMiddleware({
+          target: `http://${process.env.SONOS_HOST}`,
+          changeOrigin: true,
+          pathRewrite: { '^/sonos': '/' },
+          logger: { error: console.error, info: console.info },
+        })
+      );
     },
+    
   };
 }
 

--- a/webui/web.py
+++ b/webui/web.py
@@ -46,6 +46,8 @@ rlog.setLevel(logging.INFO)
 rlog.addFilter(CleanLogs())
 
 dist_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'dist')
+if not os.path.exists(dist_folder):
+    dist_folder = os.path.dirname(dist_folder)
 
 upload_folder = '/tmp/uploads'
 os.makedirs(upload_folder, exist_ok=True)
@@ -220,6 +222,41 @@ def influx_proxy(route):
     response_headers = [(name, value) for (
         name, value) in resp.raw.headers.items() if name.lower() not in excluded_headers]
     return Response(resp.content, resp.status_code, response_headers)
+
+
+@app.route('/sonos/<path:path>', methods=['GET'])
+def sonos_proxy(path):
+    sonos_host = os.environ.get('SONOS_HOST')
+    
+    if not sonos_host:
+        return Response('Missing SONOS_HOST', status=500)
+    
+    url = f"http://{sonos_host}/{path}"
+    
+    # Forward the request to the Sonos API server
+    try:
+        resp = requests.request(
+            method=request.method,
+            url=url,
+            headers=dict(request.headers),
+            data=request.get_data(),
+            params=request.args,
+            cookies=request.cookies,
+            allow_redirects=False,
+            timeout=5,
+        )
+        
+        # Filter out hop-by-hop headers
+        excluded_headers = ['content-encoding', 'content-length', 
+                           'transfer-encoding', 'connection']
+        response_headers = [(name, value) for (name, value) in resp.raw.headers.items() 
+                           if name.lower() not in excluded_headers]
+        
+        return Response(resp.content, resp.status_code, response_headers)
+        
+    except requests.exceptions.RequestException as e:
+        logging.error("Error proxying Sonos request to %s: %s", url, e)
+        return Response('Sonos API unavailable', status=502)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- New Sonos widget displaying currently playing zones with full controls
- Real-time playback controls: play/pause, next, volume adjustment, mute
- Shows track info and album artwork for active zones
- Optimistic UI updates for instant feedback

## Features Added
- **SonosWidget component**: Displays zones with `playbackState=PLAYING`  
- **Real-time controls**: Play/pause, next track, volume ±5, mute/unmute
- **Track display**: Shows "artist - title" and album artwork
- **Auto-refresh**: Updates every 5 seconds for current state
- **Optimistic updates**: Mute button updates UI immediately
- **Responsive design**: Centered layout, max 50vw width
- **Flask proxy**: Added `/sonos/` endpoint for API calls

## Technical Details
- Added `useSonosQuery` hook with 5-second refresh interval
- Integrated Sonos proxy in Flask server (`web.py`)
- TypeScript types for full Sonos API response structure
- Conditional rendering to prevent duplication in fullscreen mode
- Volume controls use relative API endpoints (`+5`/`-5`)

## Test plan
- [x] Widget appears on main dashboard (not in fullscreen)
- [x] Shows only playing zones with correct track info
- [x] All control buttons work with proper API calls
- [x] Mute button updates immediately (optimistic UI)
- [x] Volume controls adjust by 5-step increments
- [x] Auto-refreshes every 5 seconds
- [x] Responsive design works on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)