### PR TITLE
Fix Sonos widget card width constraints

### DIFF
--- a/webui/src/components/SonosWidget.tsx
+++ b/webui/src/components/SonosWidget.tsx
@@ -44,7 +44,7 @@ const SonosZoneCard: React.FC<SonosZoneCardProps> = ({ zone, onPlayPause, onNext
   };
 
   return (
-    <div className="flex-1 min-w-[200px] bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm border border-gray-200 dark:border-gray-700">
+    <div className="flex-1 min-w-[200px] max-w-[calc(50%-0.25rem)] bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm border border-gray-200 dark:border-gray-700">
       <div className="flex items-center gap-3">
         {currentTrack.absoluteAlbumArtUri && (
           <img 
@@ -224,7 +224,7 @@ const SonosWidget: React.FC = () => {
 
   return (
     <div className="w-full flex justify-center">
-      <div className="max-w-[50vw] w-full">
+      <div className="w-full">
         <div className="flex gap-2 flex-wrap justify-center">
           {playingZones.map(zone => (
             <SonosZoneCard 


### PR DESCRIPTION
## Summary
- Removed `max-w-[50vw]` constraint from container to allow full width
- Added `max-w-[calc(50%-0.25rem)]` to individual cards to maintain 50% card width
- Container now spans 100% width while cards stay at 50% maximum
- Single cards will center properly

## Test plan
- [ ] Verify container spans full width
- [ ] Verify each card is constrained to 50% width
- [ ] Verify single card centers correctly
- [ ] Test with multiple playing zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)