### PR TITLE
fix: update energy price bar thresholds to fixed values

### DIFF
--- a/webui/src/components/EnergyPriceBar.tsx
+++ b/webui/src/components/EnergyPriceBar.tsx
@@ -50,9 +50,6 @@ const EnergyPriceBar: React.FC = () => {
     return <Wrapper>Inga energipriser tillgängliga.</Wrapper>;
   }
 
-  const minValue = Math.min(...values, 0);
-  const maxValue = Math.max(...values, 150);
-
   const getBucketColorClass = (value: number | null): string => {
     if (value === undefined || value === null) {
       return 'bg-gray-200 dark:bg-gray-700';


### PR DESCRIPTION
Update energy price bar to use fixed thresholds instead of dynamic calculation. Green for prices below 100 öre, yellow between 100-150 öre, and red above 150 öre.