### PR TITLE
feat: auto-backfill ngenic data on startup

### DIFF
--- a/fetcher-core/python/src/main.py
+++ b/fetcher-core/python/src/main.py
@@ -9,7 +9,7 @@ import schedule
 # from balboa import balboa_control  # Disabled - now handled by Home Assistant
 from deco import deco
 from elpris import elpris
-from ngenic import ngenic
+from ngenic import ngenic, ngenic_backfill
 from aqualink import aqualink
 from airquality import airquality
 from aquatemp import aquatemp
@@ -45,14 +45,17 @@ if os.environ.get('PYDEBUGGER', None):
 
 
 def main():
-    if len(sys.argv) > 1 and sys.argv[1] in ['deco', 'elpris', 'ngenic', 'aqualink', 'aquatemp', 'airquality', 'tapo', 'sonos', 'backup_vm', 'eufy', 'eufy_snapshot']:
+    if len(sys.argv) > 1 and sys.argv[1] in ['deco', 'elpris', 'ngenic', 'ngenic_backfill', 'aqualink', 'aquatemp', 'airquality', 'tapo', 'sonos', 'backup_vm', 'eufy', 'eufy_snapshot']:
         module_name = sys.argv[1]
         logging.info(f"Running module: {module_name}")
-        for m in [deco, elpris, ngenic, aqualink, aquatemp, airquality, tapo, sonos, backup_vm, eufy, eufy_snapshot]:
+        for m in [deco, elpris, ngenic, ngenic_backfill, aqualink, aquatemp, airquality, tapo, sonos, backup_vm, eufy, eufy_snapshot]:
             if m.__name__ == module_name:
                 logging.info(f"Executing {module_name} module...")
                 m()
         return
+
+    logging.info("Running ngenic backfill check...")
+    ngenic_backfill()
 
     logging.info("Starting the scheduler...")
     schedule.every(1).minutes.do(with_timeout(aqualink))

--- a/fetcher-core/python/src/ngenic.py
+++ b/fetcher-core/python/src/ngenic.py
@@ -1,8 +1,10 @@
 
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+import httpx
 from ngenicpy import Ngenic
 from ngenicpy.models.node import NodeType, Node, NodeStatus
 from ngenicpy.models.measurement import Measurement, MeasurementType
@@ -13,8 +15,14 @@ from influx import write_influx, Point
 logger = logging.getLogger(__name__)
 
 ngenic_token = os.environ.get('NGENIC_TOKEN', '')
+influx_host = os.environ.get('INFLUX_HOST', '')
+influx_token = os.environ.get('INFLUX_TOKEN', '')
 
 logging.getLogger("httpx").setLevel(level=logging.WARNING)
+
+BACKFILL_MAX_DAYS = 30
+BACKFILL_GAP_THRESHOLD_MINUTES = 10
+BACKFILL_PERIOD = "PT5M"
 
 
 def ngenic():
@@ -26,6 +34,114 @@ def ngenic():
         _ngenic()
     except:
         logger.exception("[ngenic] Failed to execute ngenice module")
+
+
+def ngenic_backfill():
+    if not ngenic_token:
+        logger.error("[ngenic] NGENIC_TOKEN not set, skipping backfill")
+        return
+    try:
+        _ngenic_backfill()
+    except:
+        logger.exception("[ngenic] Failed to execute ngenic backfill")
+
+
+def _get_last_ngenic_timestamp() -> Optional[datetime]:
+    if not influx_host or not influx_token:
+        return None
+    try:
+        resp = httpx.get(
+            f"{influx_host}/api/v1/query",
+            params={"query": "timestamp(last_over_time(ngenic_node_sensor_measurement_value_temperature_C[30d]))"},
+            headers={"Authorization": f"Bearer {influx_token}"},
+            timeout=10,
+        )
+        data = resp.json()
+        results = data.get("data", {}).get("result", [])
+        if not results:
+            return None
+        ts = float(results[0]["value"][1])
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    except Exception as e:
+        logger.warning("[ngenic] Failed to query last timestamp: %s", e)
+        return None
+
+
+def _ngenic_backfill():
+    last_ts = _get_last_ngenic_timestamp()
+    now = datetime.now(timezone.utc)
+
+    if last_ts is None:
+        backfill_from = now - timedelta(days=BACKFILL_MAX_DAYS)
+        logger.info("[ngenic] No existing data found, backfilling %d days", BACKFILL_MAX_DAYS)
+    else:
+        gap = now - last_ts
+        if gap < timedelta(minutes=BACKFILL_GAP_THRESHOLD_MINUTES):
+            logger.info("[ngenic] Data is fresh (last: %s, gap: %s), skipping backfill", last_ts.isoformat(), gap)
+            return
+        backfill_from = last_ts
+        gap_days = gap.total_seconds() / 86400
+        if gap_days > BACKFILL_MAX_DAYS:
+            backfill_from = now - timedelta(days=BACKFILL_MAX_DAYS)
+            gap_days = BACKFILL_MAX_DAYS
+        logger.info("[ngenic] Data gap detected (last: %s, gap: %.1f days), backfilling...", last_ts.isoformat(), gap_days)
+
+    with Ngenic(token=ngenic_token) as ng:
+        tune = ng.tunes()[0]
+        nodes = tune.nodes()
+
+        for node in nodes:
+            node_type: NodeType = node.get_type()
+            if node_type not in (NodeType.CONTROLLER, NodeType.SENSOR):
+                continue
+
+            measurement_types = node.measurement_types()
+            for mtype in measurement_types:
+                chunk_start = backfill_from
+                while chunk_start < now:
+                    chunk_end = min(chunk_start + timedelta(days=1), now)
+                    from_str = chunk_start.strftime('%Y-%m-%dT%H:%M:%SZ')
+                    to_str = chunk_end.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+                    try:
+                        measurements = node.measurement(
+                            mtype, from_dt=from_str, to_dt=to_str, period=BACKFILL_PERIOD,
+                        )
+                    except Exception as e:
+                        logger.warning("[ngenic] Backfill fetch failed for %s node %s (%s -> %s): %s",
+                                       mtype.value, node.uuid()[:8], from_str, to_str, e)
+                        chunk_start = chunk_end
+                        continue
+
+                    if not measurements:
+                        chunk_start = chunk_end
+                        continue
+
+                    if not isinstance(measurements, list):
+                        measurements = [measurements]
+
+                    points: List[Point] = []
+                    for m in measurements:
+                        if not m.get("hasValue", False):
+                            continue
+                        time_str = m["time"]  # "2026-03-07T18:38:43 Etc/UTC"
+                        ts = datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S %Z").replace(tzinfo=timezone.utc)
+                        points.append(
+                            Point("ngenic_node_sensor_measurement_value")
+                            .tag("node", node.uuid())
+                            .tag("node_type", node_type.name)
+                            .field(mtype.value, float(m["value"]))
+                            .time(int(ts.timestamp()))
+                        )
+
+                    if points:
+                        logger.info("[ngenic] Backfill: %d points for %s node %s (%s)",
+                                    len(points), mtype.value, node.uuid()[:8], from_str[:10])
+                        write_influx(points)
+
+                    chunk_start = chunk_end
+
+    logger.info("[ngenic] Backfill complete")
 
 
 def _ngenic():


### PR DESCRIPTION
## Summary
- On startup, queries VictoriaMetrics for the last ngenic data timestamp
- If a gap > 10 minutes is detected (up to 30 days), fetches historical measurements from the Ngenic API
- Uses 1-day chunks with 5-minute resolution (`PT5M`) to avoid large API responses
- Also available as standalone module: `python main.py ngenic_backfill`

## Test plan
- [ ] Deploy to rpi5 and verify backfill runs on startup
- [ ] Check logs for backfill progress messages
- [ ] Verify data gap in Grafana is filled after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)