### PR TITLE
feat(sonos): switch to tkhduracell/sonos-http-api fork

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       - TZ=Europe/Stockholm
 
   sonos-http-api:
-    image: chrisns/docker-node-sonos-http-api:latest
+    image: ghcr.io/tkhduracell/sonos-http-api:master
     hostname: sonos-http-api
     restart: unless-stopped
     network_mode: host


### PR DESCRIPTION
Switch the sonos-http-api Docker image from the third-party chrisns/docker-node-sonos-http-api to our own fork at ghcr.io/tkhduracell/sonos-http-api:master. The fork's CI builds multi-arch images (amd64 + arm64) and publishes to GHCR.