### PR TITLE
Add battery charging power metric and fix decimal display

### DIFF
--- a/fetcher-core/webui/app/components/LatestValue.tsx
+++ b/fetcher-core/webui/app/components/LatestValue.tsx
@@ -47,7 +47,7 @@ const LatestValue: React.FC<LatestValueProps> = (props) => {
             <span className={
               `font-semibold ${loading ? 'text-gray-500 dark:text-gray-400' : 'text-blue-700 dark:text-blue-200'} ${valueSizeClass(colCount)} tracking-[-0.01em]`
             }>
-              {value?.toFixed(decimals).replace(/\.0$/, '')}
+              {value?.toFixed(decimals)}
             </span>
             <span className="text-sm md:text-base text-blue-700/80 dark:text-blue-200/80">
               {unit}

--- a/fetcher-core/webui/app/lib/values.ts
+++ b/fetcher-core/webui/app/lib/values.ts
@@ -24,5 +24,6 @@ export const values: Config = [
         { measurement: 'sigenergy_grid_power', field: 'net_power_kw', title: '⚡️ Nät Inköp', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: -5, sparklineMax: 10 },
         { measurement: 'sigenergy_battery', field: 'soc_percent', title: '🔋 Batteri SOC', unit: '%', decimals: 0, reload: 60000, sparkline: '24h', sparklineMin: 0, sparklineMax: 100 },
         { measurement: 'sigenergy_battery', field: 'power_to_battery_kw', title: '🪫 Batteri Urladdning', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: -10, sparklineMax: 10 },
+        { measurement: 'sigenergy_battery', field: 'power_from_battery_kw', title: '🔋 Batteri Laddning', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: 0, sparklineMax: 10 },
     ],
 ];


### PR DESCRIPTION
## Summary
This PR adds a new battery charging power metric to the dashboard and fixes the decimal formatting for displayed values.

## Key Changes
- **Added battery charging metric**: New configuration entry for `power_from_battery_kw` field to display battery charging power (🔋 Batteri Laddning) with 1 decimal place and a sparkline visualization
- **Fixed decimal display**: Removed the regex replacement that was stripping trailing `.0` from fixed decimal values, ensuring consistent decimal formatting across all metrics

## Implementation Details
- The new battery charging metric mirrors the existing battery discharging metric (`power_to_battery_kw`) with appropriate title and sparkline range (0-10 kW)
- The decimal formatting change in `LatestValue.tsx` ensures that values like `5.0` are displayed as-is rather than being converted to `5`, providing consistent precision display based on the configured decimal places

https://claude.ai/code/session_015piR5p46RF46REHruWDwKj