### PR TITLE
Add next-day price navigation arrow to EnergyPriceBar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pinout.png
 **/.next
 **/next-env.d.ts
 **/dev.log
+**/*.tsbuildinfo
 
 /backup/
 *.tar

--- a/fetcher-core/webui/app/components/EnergyPriceBar.tsx
+++ b/fetcher-core/webui/app/components/EnergyPriceBar.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import usePromQLQuery from '../hooks/usePromQLQuery';
-import { startOfDay, endOfDay, differenceInMinutes } from 'date-fns';
+import { startOfDay, endOfDay, differenceInMinutes, addDays } from 'date-fns';
 
 type Point = {
   _time: string;
@@ -15,13 +15,30 @@ const Wrapper = (props: { children: React.ReactNode }) => {
   );
 }
 
+const getBucketColorClass = (value: number | null | undefined): string => {
+  if (value === undefined || value === null) {
+    return 'bg-gray-200 dark:bg-gray-700';
+  }
+  if (value < 100) {
+    return 'bg-green-400 dark:bg-green-700';
+  } else if (value <= 150) {
+    return 'bg-yellow-400 dark:bg-yellow-700';
+  } else {
+    return 'bg-red-400 dark:bg-red-700';
+  }
+};
+
 const EnergyPriceBar: React.FC = () => {
   const measurement = 'energy_price';
   const field = '100th_SEK_per_kWh';
   const filterTag = 'SE4';
 
-  const start = startOfDay(new Date());
-  const end = endOfDay(new Date());
+  const now = new Date();
+  const todayStart = startOfDay(now);
+  const tomorrowStart = startOfDay(addDays(now, 1));
+  const rangeEnd = endOfDay(addDays(now, 1));
+
+  const [view, setView] = useState<'today' | 'tomorrow'>('today');
 
   const promQuery = useMemo(() => {
     return `avg_over_time(${measurement}_${field}{area="${filterTag}"}[1h])`;
@@ -30,67 +47,101 @@ const EnergyPriceBar: React.FC = () => {
   const { initialLoading, error, result } = usePromQLQuery({
     query: promQuery,
     type: 'range',
-    start: start.toISOString(),
-    end: end.toISOString(),
+    start: todayStart.toISOString(),
+    end: rangeEnd.toISOString(),
     step: '1h',
   });
+
+  const { todayPoints, tomorrowPoints } = useMemo(() => {
+    const todayP: Point[] = [];
+    const tomorrowP: Point[] = [];
+    const tomorrowStartMs = tomorrowStart.getTime();
+    for (const p of result) {
+      if (p.value === undefined || p.value === null || Number.isNaN(p.value)) continue;
+      const t = new Date(p._time).getTime();
+      if (t < tomorrowStartMs) {
+        todayP.push(p);
+      } else {
+        tomorrowP.push(p);
+      }
+    }
+    return { todayPoints: todayP, tomorrowPoints: tomorrowP };
+  }, [result, tomorrowStart]);
+
+  const hasTomorrow = tomorrowPoints.length > 0;
+
+  useEffect(() => {
+    if (view === 'tomorrow' && !hasTomorrow) {
+      setView('today');
+    }
+  }, [view, hasTomorrow]);
 
   if (initialLoading && !error) return <Wrapper>Hämtar energipriser...</Wrapper>;
   if (error) return <Wrapper>Fel uppstod vid laddning: {error.message}</Wrapper>;
 
-  const values = result.map(p => p.value).filter(v => v !== undefined && v !== null);
-  if (values.length === 0) {
+  if (todayPoints.length === 0 && tomorrowPoints.length === 0) {
     return <Wrapper>Inga energipriser tillgängliga.</Wrapper>;
   }
 
-  const getBucketColorClass = (value: number | null): string => {
-    if (value === undefined || value === null) {
-      return 'bg-gray-200 dark:bg-gray-700';
-    }
-    if (value < 100) {
-      return 'bg-green-400 dark:bg-green-700';
-    } else if (value <= 150) {
-      return 'bg-yellow-400 dark:bg-yellow-700';
-    } else {
-      return 'bg-red-400 dark:bg-red-700';
-    }
-  };
-
-      return (
-        <Wrapper>
-          <div className="w-full flex gap-1 flex-wrap">
-            {result.map((point: Point) => {
-              const value = point.value;
-              const colorClass = getBucketColorClass(value);
-              const time = new Date(point._time);
-              const diff = differenceInMinutes(time, Date.now());
-              const isNow = ( diff < 59 &&  diff > 0 );
-              return (
-                <div className='flex flex-1 flex-col justify-end' key={point._time}>
-                  <div className={
-                    `${colorClass} rounded p-0 flex h-8
-                    text-center text-gray-600 justify-center items-center
-                    dark:text-gray-300 ${isNow ? 'text-sm font-semibold ring-inset ring-2 ring-gray-500' : 'text-[10px]'}`}>
-                      {value?.toFixed(0)}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="w-full flex flex-row justify-between text-[10px] text-gray-600 dark:text-gray-300">
-            <div className='bg-green-400 dark:bg-green-700 rounded px-1 py-0.5'>
-              &lt; 100 öre
-            </div>
-            <div className='bg-yellow-400 dark:bg-yellow-700 rounded px-1 py-0.5'>
-              100–150 öre
-            </div>
-            <div className='bg-red-400 dark:bg-red-700 rounded px-1 py-0.5'>
-              &gt; 150 öre
+  const renderCells = (points: Point[], highlightNow: boolean) => (
+    <div className="w-1/2 flex gap-1">
+      {points.map((point) => {
+        const value = point.value;
+        const colorClass = getBucketColorClass(value);
+        const time = new Date(point._time);
+        const diff = differenceInMinutes(time, Date.now());
+        const isNow = highlightNow && diff < 59 && diff > 0;
+        return (
+          <div className='flex flex-1 flex-col justify-end' key={point._time}>
+            <div className={
+              `${colorClass} rounded p-0 flex h-8
+              text-center text-gray-600 justify-center items-center
+              dark:text-gray-300 ${isNow ? 'text-sm font-semibold ring-inset ring-2 ring-gray-500' : 'text-[10px]'}`}>
+                {value?.toFixed(0)}
             </div>
           </div>
-        </Wrapper>
-      );
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <Wrapper>
+      <div className="w-full flex gap-1 items-stretch">
+        <div className="relative overflow-hidden flex-1">
+          <div
+            className="flex w-[200%] transition-transform duration-300 ease-out"
+            style={{ transform: view === 'today' ? 'translateX(0)' : 'translateX(-50%)' }}
+          >
+            {renderCells(todayPoints, true)}
+            {renderCells(tomorrowPoints, false)}
+          </div>
+        </div>
+        {hasTomorrow && (
+          <button
+            type="button"
+            onClick={() => setView(view === 'today' ? 'tomorrow' : 'today')}
+            aria-label={view === 'today' ? 'Visa morgondagens priser' : 'Tillbaka till dagens priser'}
+            className="h-8 px-2 flex items-center justify-center rounded bg-blue-200 dark:bg-blue-800 hover:bg-blue-300 dark:hover:bg-blue-700 text-gray-700 dark:text-gray-200 text-sm font-semibold shadow-sm shrink-0 cursor-pointer transition-colors duration-200"
+          >
+            {view === 'today' ? '»' : '«'}
+          </button>
+        )}
+      </div>
+
+      <div className="w-full flex flex-row justify-between text-[10px] text-gray-600 dark:text-gray-300">
+        <div className='bg-green-400 dark:bg-green-700 rounded px-1 py-0.5'>
+          &lt; 100 öre
+        </div>
+        <div className='bg-yellow-400 dark:bg-yellow-700 rounded px-1 py-0.5'>
+          100–150 öre
+        </div>
+        <div className='bg-red-400 dark:bg-red-700 rounded px-1 py-0.5'>
+          &gt; 150 öre
+        </div>
+      </div>
+    </Wrapper>
+  );
 };
 
 export default EnergyPriceBar;


### PR DESCRIPTION
## Summary

- Extend the `EnergyPriceBar` range query to cover **today + tomorrow** in one shot, then bucket the rows into two day-arrays in `useMemo`.
- Render the cells inside a `overflow-hidden` viewport with a `w-[200%]` track; toggling view state slides the track via `translateX(0 → -50%)` with a 300ms CSS transition.
- A small arrow button (`»` / `«`) appears on the right of the bar **only when `tomorrowPoints.length > 0`** — i.e. only after Nord Pool/elprisetjustnu.se has actually published tomorrow's prices (typically ~13–14:00 Europe/Stockholm). No time-based heuristic; purely data-driven.
- Clicking the arrow toggles between today and tomorrow; the "current hour" ring highlight only renders when viewing today.
- A `useEffect` safety-net snaps back to today if tomorrow's data disappears on a later reload (e.g. day rollover).

No backend or API changes — the Python ingest (`fetcher-core/python/src/elpris.py`) already fetches next-day prices into VictoriaMetrics, and `usePromQLQuery` already supports arbitrary range queries.

## Test plan

- [ ] `npm run typecheck` passes (verified)
- [ ] `npm run build` passes (verified)
- [ ] Before tomorrow's prices are published: only today renders, no arrow
- [ ] After publication: `»` appears on the right; click slides left smoothly; `«` appears and returns to today
- [ ] Current-hour ring only shows on today's view
- [ ] Dark-mode contrast on the arrow button looks good
- [ ] Deploy to rpi5 and observe behaviour across the 13:00–14:00 Europe/Stockholm boundary

https://claude.ai/code/session_01299dKhDUtCcY5SnvZHSvux