### PR TITLE
Add Go pool-pump-planner MILP sidecar container

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -171,3 +171,73 @@ jobs:
         platforms: linux/amd64,linux/arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+  test-pool-pump-planner:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: ./pool-pump-planner/go.mod
+        cache: false
+
+    - name: Go vet
+      working-directory: ./pool-pump-planner
+      run: go vet ./...
+
+    - name: Go test
+      working-directory: ./pool-pump-planner
+      run: go test ./...
+
+  build-pool-pump-planner:
+    runs-on: ubuntu-latest
+    needs: test-pool-pump-planner
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - uses: 'google-github-actions/auth@v3'
+      id: auth
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+      with:
+        token_format: access_token
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER_ID }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+    - uses: docker/login-action@v4
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+      with:
+        registry: europe-docker.pkg.dev
+        username: oauth2accesstoken
+        password: '${{ steps.auth.outputs.access_token }}'
+
+    - name: Build And Push pool-pump-planner image
+      uses: docker/build-push-action@v7
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+      with:
+        context: ./pool-pump-planner/
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: europe-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/images/pool-pump-planner:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build pool-pump-planner image
+      uses: docker/build-push-action@v7
+      if: ${{ !(github.ref == 'refs/heads/main' && github.event_name != 'pull_request') }}
+      with:
+        context: ./pool-pump-planner/
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@ build-proxy:
 push-proxy: build-proxy
 	(cd ./https-proxy && make push)
 
+build-pool-pump-planner:
+	(cd ./pool-pump-planner && make build)
+
+push-pool-pump-planner: build-pool-pump-planner
+	(cd ./pool-pump-planner && make push)
+
 login:
 	balena login -H --token "$$(sed -n 's/^BALENA_TOKEN=//p' .env)"
 
 deploy: push-fetcher push-proxy login
 	balena push iot-hub
 
-.PHONY: build-fetcher push-fetcher deploy build-proxy push-proxy login run-proxy
+.PHONY: build-fetcher push-fetcher deploy build-proxy push-proxy build-pool-pump-planner push-pool-pump-planner login run-proxy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,3 +6,6 @@ services:
 
   ai-assistant:
     build: ./ai-assistant
+
+  pool-pump-planner:
+    build: ./pool-pump-planner

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -23,6 +23,10 @@ services:
       - ./fetcher-core/python/.env
       - ./fetcher-core/webui/.env
 
+  pool-pump-planner:
+    container_name: pool-pump-planner
+    env_file: ./fetcher-core/python/.env
+
   tibber-influx-bridge:
     container_name: tibber-influxdb-bridge
     env_file: ./tibber-influx-bridge/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,15 @@ services:
       - "wud.watch=true"
       - "wud.watch.digest=true"
 
+  pool-pump-planner:
+    image: europe-docker.pkg.dev/filiplindqvist-com-ea66d/images/pool-pump-planner:latest
+    restart: unless-stopped
+    depends_on:
+      - database-auth
+    labels:
+      - "wud.watch=true"
+      - "wud.watch.digest=true"
+
   tibber-influx-bridge:
     image: tkhduracell/tibber-influxdb-bridge:latest
     restart: unless-stopped

--- a/pool-pump-planner/.gitignore
+++ b/pool-pump-planner/.gitignore
@@ -1,0 +1,3 @@
+pool-pump-planner
+/pool-pump-planner
+*.test

--- a/pool-pump-planner/Dockerfile
+++ b/pool-pump-planner/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: build the Go binary
+FROM golang:1.22-bookworm AS build
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/pool-pump-planner .
+
+# Stage 2: runtime with CBC
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates coinor-cbc tzdata \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=build /out/pool-pump-planner /usr/local/bin/pool-pump-planner
+ENTRYPOINT ["/usr/local/bin/pool-pump-planner"]

--- a/pool-pump-planner/Dockerfile
+++ b/pool-pump-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build the Go binary
-FROM golang:1.22-bookworm AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /src
 COPY go.mod ./
 RUN go mod download

--- a/pool-pump-planner/Dockerfile
+++ b/pool-pump-planner/Dockerfile
@@ -1,4 +1,11 @@
-# Stage 1: build the Go binary
+# Stage 1: runtime deps (cached independently of Go sources — BuildKit can
+# pull this in parallel with the Go build stage below)
+FROM debian:bookworm-slim AS runtime-deps
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates coinor-cbc tzdata \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Stage 2: build the Go binary
 FROM golang:1.26-bookworm AS build
 WORKDIR /src
 COPY go.mod ./
@@ -6,10 +13,7 @@ RUN go mod download
 COPY *.go ./
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/pool-pump-planner .
 
-# Stage 2: runtime with CBC
-FROM debian:bookworm-slim
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates coinor-cbc tzdata \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Stage 3: final image
+FROM runtime-deps
 COPY --from=build /out/pool-pump-planner /usr/local/bin/pool-pump-planner
 ENTRYPOINT ["/usr/local/bin/pool-pump-planner"]

--- a/pool-pump-planner/Makefile
+++ b/pool-pump-planner/Makefile
@@ -1,0 +1,17 @@
+IMAGE := europe-docker.pkg.dev/filiplindqvist-com-ea66d/images/pool-pump-planner:latest
+
+build:
+	docker build -t $(IMAGE) .
+
+push: build
+	gcloud auth configure-docker europe-docker.pkg.dev
+	docker push $(IMAGE)
+
+run: build
+	docker run --rm --env-file ../fetcher-core/python/.env $(IMAGE) --once
+
+test:
+	go vet ./...
+	go test ./...
+
+.PHONY: build push run test

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	// InfluxDB / VictoriaMetrics
+	InfluxHost     string
+	InfluxToken    string
+	InfluxDatabase string
+	VMURL          string
+	VMToken        string
+
+	// Location / PV
+	GoogleLatLng  string
+	PVDeclination float64
+	PVAzimuth     float64
+	PVKWp         float64
+
+	// Pump
+	PumpKW            float64
+	GridFeeSEKPerKWh  float64
+
+	// Scheduling
+	MinHours     int
+	TargetHours  int
+	MaxHours     int
+	MaxStarts    int
+	BlockedHours []int
+
+	FallbackNightHours     []int
+	FallbackAfternoonHours []int
+
+	// Temperature driven target override
+	TargetTempC          float64
+	HeatingRateCPerHour  float64
+
+	PriceArea    string
+	Timezone     *time.Location
+	SlotMinutes  int
+
+	// Scheduling
+	PlanTime string // HH:MM, site-local
+}
+
+func loadConfig() *Config {
+	cfg := &Config{
+		InfluxHost:     getenv("INFLUX_HOST", ""),
+		InfluxToken:    getenv("INFLUX_TOKEN", ""),
+		InfluxDatabase: getenv("INFLUX_DATABASE", "irisgatan"),
+		VMURL:          getenv("INFLUXDB_V3_URL", ""),
+		VMToken:        getenv("INFLUXDB_V3_ACCESS_TOKEN", ""),
+
+		GoogleLatLng:  getenv("GOOGLE_LAT_LNG", ""),
+		PVDeclination: getenvFloat("POOL_PV_DECLINATION", 30),
+		PVAzimuth:     getenvFloat("POOL_PV_AZIMUTH", 0),
+		PVKWp:         getenvFloat("POOL_PV_KWP", 3.0),
+
+		PumpKW:           getenvFloat("POOL_PUMP_KW", 4.0),
+		GridFeeSEKPerKWh: getenvFloat("POOL_GRID_FEE_SEK_PER_KWH", 0.80),
+
+		MinHours:     getenvInt("POOL_MIN_HOURS", 4),
+		TargetHours:  getenvInt("POOL_TARGET_HOURS", 6),
+		MaxHours:     getenvInt("POOL_MAX_HOURS", 10),
+		MaxStarts:    getenvInt("POOL_MAX_STARTS", 2),
+		BlockedHours: getenvIntList("POOL_BLOCKED_HOURS", []int{7, 8, 17, 18, 19, 20}),
+
+		FallbackNightHours:     getenvIntList("POOL_FALLBACK_NIGHT_HOURS", []int{1, 2, 3, 4}),
+		FallbackAfternoonHours: getenvIntList("POOL_FALLBACK_AFTERNOON_HOURS", []int{12, 13, 14, 15}),
+
+		TargetTempC:         getenvFloat("POOL_TARGET_TEMP_C", 29),
+		HeatingRateCPerHour: getenvFloat("POOL_HEATING_RATE_C_PER_HOUR", 0),
+
+		PriceArea:   getenv("POOL_PRICE_AREA", "SE4"),
+		SlotMinutes: getenvInt("POOL_SLOT_MINUTES", 15),
+		PlanTime:    getenv("POOL_PLAN_TIME", "14:05"),
+	}
+
+	tzName := getenv("POOL_TIMEZONE", "Europe/Stockholm")
+	tz, err := time.LoadLocation(tzName)
+	if err != nil {
+		tz = time.UTC
+	}
+	cfg.Timezone = tz
+
+	if cfg.VMToken == "" {
+		cfg.VMToken = cfg.InfluxToken
+	}
+
+	return cfg
+}
+
+func (c *Config) SlotsPerHour() int { return 60 / c.SlotMinutes }
+func (c *Config) HorizonSlots() int { return 24 * c.SlotsPerHour() }
+func (c *Config) SlotHours() float64 {
+	return float64(c.SlotMinutes) / 60.0
+}
+
+func getenv(k, def string) string {
+	if v, ok := os.LookupEnv(k); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func getenvInt(k string, def int) int {
+	if v, ok := os.LookupEnv(k); ok && v != "" {
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func getenvFloat(k string, def float64) float64 {
+	if v, ok := os.LookupEnv(k); ok && v != "" {
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func getenvIntList(k string, def []int) []int {
+	v, ok := os.LookupEnv(k)
+	if !ok || strings.TrimSpace(v) == "" {
+		return def
+	}
+	out := []int{}
+	for _, p := range strings.Split(v, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return def
+	}
+	return out
+}

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -91,7 +93,22 @@ func loadConfig() *Config {
 		cfg.VMToken = cfg.InfluxToken
 	}
 
+	if err := cfg.validate(); err != nil {
+		log.Fatalf("invalid configuration: %v", err)
+	}
 	return cfg
+}
+
+func (c *Config) validate() error {
+	// SlotMinutes must evenly tile a clock hour so SlotsPerHour() stays well-defined
+	// and plan timestamps align with Nord Pool's hourly pricing buckets.
+	if c.SlotMinutes <= 0 || 60%c.SlotMinutes != 0 {
+		return fmt.Errorf("POOL_SLOT_MINUTES must be a positive divisor of 60, got %d", c.SlotMinutes)
+	}
+	if c.MinHours < 0 || c.MaxHours < c.MinHours {
+		return fmt.Errorf("POOL_MIN_HOURS (%d) must be <= POOL_MAX_HOURS (%d)", c.MinHours, c.MaxHours)
+	}
+	return nil
 }
 
 func (c *Config) SlotsPerHour() int { return 60 / c.SlotMinutes }

--- a/pool-pump-planner/go.mod
+++ b/pool-pump-planner/go.mod
@@ -1,3 +1,3 @@
 module github.com/tkhduracell/iot-fetcher/pool-pump-planner
 
-go 1.22
+go 1.26

--- a/pool-pump-planner/go.mod
+++ b/pool-pump-planner/go.mod
@@ -1,0 +1,3 @@
+module github.com/tkhduracell/iot-fetcher/pool-pump-planner
+
+go 1.22

--- a/pool-pump-planner/influx.go
+++ b/pool-pump-planner/influx.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Point struct {
+	Measurement string
+	Tags        map[string]string
+	Fields      map[string]any // float64, int, bool, or string
+	Time        time.Time
+}
+
+func NewPoint(m string) *Point {
+	return &Point{
+		Measurement: m,
+		Tags:        map[string]string{},
+		Fields:      map[string]any{},
+	}
+}
+
+func (p *Point) Tag(k, v string) *Point      { p.Tags[k] = v; return p }
+func (p *Point) Field(k string, v any) *Point { p.Fields[k] = v; return p }
+func (p *Point) At(t time.Time) *Point        { p.Time = t; return p }
+
+// Encode a single point in InfluxDB line protocol with second precision.
+func (p *Point) lineProtocol() string {
+	var b strings.Builder
+	b.WriteString(escapeMeasurement(p.Measurement))
+	// tags in sorted order for determinism
+	keys := sortedKeys(p.Tags)
+	for _, k := range keys {
+		b.WriteString(",")
+		b.WriteString(escapeTag(k))
+		b.WriteString("=")
+		b.WriteString(escapeTag(p.Tags[k]))
+	}
+	b.WriteString(" ")
+	firstField := true
+	for _, k := range sortedAnyKeys(p.Fields) {
+		if !firstField {
+			b.WriteString(",")
+		}
+		firstField = false
+		b.WriteString(escapeTag(k))
+		b.WriteString("=")
+		b.WriteString(encodeField(p.Fields[k]))
+	}
+	if !p.Time.IsZero() {
+		b.WriteString(" ")
+		b.WriteString(strconv.FormatInt(p.Time.Unix(), 10))
+	}
+	return b.String()
+}
+
+func encodeField(v any) string {
+	switch x := v.(type) {
+	case int:
+		return strconv.Itoa(x) + "i"
+	case int64:
+		return strconv.FormatInt(x, 10) + "i"
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case string:
+		return `"` + strings.ReplaceAll(x, `"`, `\"`) + `"`
+	default:
+		return `"` + fmt.Sprintf("%v", x) + `"`
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	return keys
+}
+
+func sortedAnyKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	return keys
+}
+
+func sortStrings(s []string) {
+	// small n, bubble-sort keeps us dependency-free
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+func escapeMeasurement(s string) string {
+	s = strings.ReplaceAll(s, ",", `\,`)
+	s = strings.ReplaceAll(s, " ", `\ `)
+	return s
+}
+
+func escapeTag(s string) string {
+	s = strings.ReplaceAll(s, ",", `\,`)
+	s = strings.ReplaceAll(s, " ", `\ `)
+	s = strings.ReplaceAll(s, "=", `\=`)
+	return s
+}
+
+// WritePoints ships points via the InfluxDB v2 line protocol endpoint. This is
+// the same surface VictoriaMetrics and InfluxDB v3 Cloud accept, mirroring the
+// Python influx.write_influx helper.
+func (c *Config) WritePoints(points []*Point) error {
+	if c.InfluxHost == "" || c.InfluxToken == "" {
+		log.Printf("[influx] INFLUX_HOST and INFLUX_TOKEN not set, skipping write of %d points", len(points))
+		return nil
+	}
+	host := c.InfluxHost
+	if !strings.Contains(host, "://") {
+		host = "https://" + host
+	}
+	host = strings.TrimRight(host, "/")
+
+	q := url.Values{}
+	q.Set("bucket", c.InfluxDatabase)
+	q.Set("precision", "s")
+	endpoint := host + "/api/v2/write?" + q.Encode()
+
+	var body bytes.Buffer
+	for _, p := range points {
+		body.WriteString(p.lineProtocol())
+		body.WriteString("\n")
+	}
+
+	req, err := http.NewRequest("POST", endpoint, &body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Token "+c.InfluxToken)
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("influx write %d: %s", resp.StatusCode, string(respBody))
+	}
+	if len(points) > 4 {
+		log.Printf("[influx] wrote %d points (%s ...)", len(points), points[0].Measurement)
+	} else {
+		names := make([]string, 0, len(points))
+		for _, p := range points {
+			names = append(names, p.Measurement)
+		}
+		log.Printf("[influx] wrote %d points (%s)", len(points), strings.Join(names, ", "))
+	}
+	return nil
+}

--- a/pool-pump-planner/main.go
+++ b/pool-pump-planner/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -39,33 +41,23 @@ func main() {
 }
 
 func parseHHMM(s string) (int, int, error) {
-	parts := strings.SplitN(s, ":", 2)
+	parts := strings.Split(s, ":")
 	if len(parts) != 2 {
-		return 0, 0, errInvalidTime
+		return 0, 0, fmt.Errorf("expected HH:MM, got %q", s)
 	}
-	hh, err1 := atoi(parts[0])
-	mm, err2 := atoi(parts[1])
-	if err1 != nil || err2 != nil || hh < 0 || hh > 23 || mm < 0 || mm > 59 {
-		return 0, 0, errInvalidTime
+	// strconv.Atoi rejects empty strings, so ":05" / "14:" / "::" all error out.
+	hh, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid hour %q: %w", parts[0], err)
+	}
+	mm, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minute %q: %w", parts[1], err)
+	}
+	if hh < 0 || hh > 23 || mm < 0 || mm > 59 {
+		return 0, 0, fmt.Errorf("out of range HH:MM in %q", s)
 	}
 	return hh, mm, nil
-}
-
-var errInvalidTime = &timeParseErr{}
-
-type timeParseErr struct{}
-
-func (e *timeParseErr) Error() string { return "expected HH:MM" }
-
-func atoi(s string) (int, error) {
-	n := 0
-	for _, c := range strings.TrimSpace(s) {
-		if c < '0' || c > '9' {
-			return 0, errInvalidTime
-		}
-		n = n*10 + int(c-'0')
-	}
-	return n, nil
 }
 
 func nextDailyRun(now time.Time, hh, mm int) time.Time {

--- a/pool-pump-planner/main.go
+++ b/pool-pump-planner/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	once := flag.Bool("once", false, "run planner once and exit")
+	flag.Parse()
+
+	cfg := loadConfig()
+
+	if *once || (len(os.Args) > 1 && os.Args[1] == "once") {
+		runPlanner(cfg)
+		return
+	}
+
+	// Run once on startup (mirroring python schedule.run_all), then daily at POOL_PLAN_TIME.
+	runPlanner(cfg)
+
+	hh, mm, err := parseHHMM(cfg.PlanTime)
+	if err != nil {
+		log.Fatalf("invalid POOL_PLAN_TIME %q: %v", cfg.PlanTime, err)
+	}
+
+	for {
+		next := nextDailyRun(time.Now().In(cfg.Timezone), hh, mm)
+		delay := time.Until(next)
+		log.Printf("[planner] next run at %s (%.0fs)", next.Format(time.RFC3339), delay.Seconds())
+		time.Sleep(delay)
+		runPlanner(cfg)
+	}
+}
+
+func parseHHMM(s string) (int, int, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, 0, errInvalidTime
+	}
+	hh, err1 := atoi(parts[0])
+	mm, err2 := atoi(parts[1])
+	if err1 != nil || err2 != nil || hh < 0 || hh > 23 || mm < 0 || mm > 59 {
+		return 0, 0, errInvalidTime
+	}
+	return hh, mm, nil
+}
+
+var errInvalidTime = &timeParseErr{}
+
+type timeParseErr struct{}
+
+func (e *timeParseErr) Error() string { return "expected HH:MM" }
+
+func atoi(s string) (int, error) {
+	n := 0
+	for _, c := range strings.TrimSpace(s) {
+		if c < '0' || c > '9' {
+			return 0, errInvalidTime
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}
+
+func nextDailyRun(now time.Time, hh, mm int) time.Time {
+	candidate := time.Date(now.Year(), now.Month(), now.Day(), hh, mm, 0, 0, now.Location())
+	if !candidate.After(now) {
+		candidate = candidate.AddDate(0, 0, 1)
+	}
+	return candidate
+}

--- a/pool-pump-planner/main_test.go
+++ b/pool-pump-planner/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestParseHHMM(t *testing.T) {
+	good := []struct {
+		in     string
+		hh, mm int
+	}{
+		{"14:05", 14, 5},
+		{"00:00", 0, 0},
+		{"23:59", 23, 59},
+		{" 9:30", 9, 30},
+	}
+	for _, tc := range good {
+		hh, mm, err := parseHHMM(tc.in)
+		if err != nil {
+			t.Errorf("parseHHMM(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if hh != tc.hh || mm != tc.mm {
+			t.Errorf("parseHHMM(%q) = %d:%d, want %d:%d", tc.in, hh, mm, tc.hh, tc.mm)
+		}
+	}
+
+	bad := []string{"", "14", "14:", ":05", "::", "25:00", "14:60", "abc:def", "14:0x"}
+	for _, in := range bad {
+		if _, _, err := parseHHMM(in); err == nil {
+			t.Errorf("parseHHMM(%q) expected error, got nil", in)
+		}
+	}
+}

--- a/pool-pump-planner/milp.go
+++ b/pool-pump-planner/milp.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type lpInput struct {
+	costs       []float64
+	blocked     map[int]bool
+	minSlots    int
+	targetSlots int
+	maxSlots    int
+	maxStarts   int
+}
+
+type lpResult struct {
+	schedule []int   // 0/1 per slot
+	slack    float64 // in slots
+	status   string
+}
+
+// solveMILP writes a CBC LP file, invokes cbc, and reads the solution back.
+// Mirrors the Python PuLP/CBC formulation in pool_pump_planner.py.
+func solveMILP(in lpInput) (*lpResult, error) {
+	dir, err := os.MkdirTemp("", "pool-pump-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	lpPath := filepath.Join(dir, "problem.lp")
+	solPath := filepath.Join(dir, "solution.txt")
+	if err := writeLP(lpPath, in); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("cbc", lpPath, "solve", "solu", solPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("cbc failed: %w (stderr=%s)", err, stderr.String())
+	}
+
+	res, err := parseCBCSolution(solPath, len(in.costs))
+	if err != nil {
+		return nil, fmt.Errorf("parse cbc solution: %w (cbc stdout=%s)", err, stdout.String())
+	}
+	return res, nil
+}
+
+func writeLP(path string, in lpInput) error {
+	T := len(in.costs)
+	bigM := 100.0
+	for _, c := range in.costs {
+		if c > bigM {
+			bigM = c
+		}
+	}
+	bigM = bigM*10 + 100
+
+	var b strings.Builder
+	b.WriteString("\\* pool pump MILP *\\\n")
+	b.WriteString("Minimize\n obj: ")
+	first := true
+	for t := 0; t < T; t++ {
+		c := in.costs[t]
+		if math.IsNaN(c) || c == 0 {
+			continue
+		}
+		if !first {
+			b.WriteString(" + ")
+		}
+		first = false
+		fmt.Fprintf(&b, "%g x_%d", c, t)
+	}
+	if !first {
+		b.WriteString(" + ")
+	}
+	fmt.Fprintf(&b, "%g slack\n", bigM)
+
+	b.WriteString("Subject To\n")
+
+	// min/target/max total run
+	writeSum(&b, "c_min", T, "x", ">=", float64(in.minSlots))
+	writeSumWithSlack(&b, "c_target", T, "x", "slack", ">=", float64(in.targetSlots))
+	writeSum(&b, "c_max", T, "x", "<=", float64(in.maxSlots))
+
+	// Start indicators: y_t >= x_t - x_{t-1}   (with x_{-1} = 0)
+	for t := 0; t < T; t++ {
+		if t == 0 {
+			fmt.Fprintf(&b, " c_start_%d: y_%d - x_%d >= 0\n", t, t, t)
+		} else {
+			fmt.Fprintf(&b, " c_start_%d: y_%d - x_%d + x_%d >= 0\n", t, t, t, t-1)
+		}
+	}
+	writeSum(&b, "c_maxstarts", T, "y", "<=", float64(in.maxStarts))
+
+	// Blocked slots forced to 0
+	for t := 0; t < T; t++ {
+		if in.blocked[t] {
+			fmt.Fprintf(&b, " c_blk_%d: x_%d = 0\n", t, t)
+		}
+	}
+
+	b.WriteString("Bounds\n")
+	b.WriteString(" slack >= 0\n")
+
+	b.WriteString("Binary\n")
+	for t := 0; t < T; t++ {
+		fmt.Fprintf(&b, " x_%d", t)
+		if t%10 == 9 {
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	for t := 0; t < T; t++ {
+		fmt.Fprintf(&b, " y_%d", t)
+		if t%10 == 9 {
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\nEnd\n")
+
+	return os.WriteFile(path, []byte(b.String()), 0644)
+}
+
+func writeSum(b *strings.Builder, name string, T int, prefix, op string, rhs float64) {
+	fmt.Fprintf(b, " %s:", name)
+	for t := 0; t < T; t++ {
+		if t == 0 {
+			fmt.Fprintf(b, " %s_%d", prefix, t)
+		} else {
+			fmt.Fprintf(b, " + %s_%d", prefix, t)
+		}
+	}
+	fmt.Fprintf(b, " %s %g\n", op, rhs)
+}
+
+func writeSumWithSlack(b *strings.Builder, name string, T int, prefix, slack, op string, rhs float64) {
+	fmt.Fprintf(b, " %s:", name)
+	for t := 0; t < T; t++ {
+		if t == 0 {
+			fmt.Fprintf(b, " %s_%d", prefix, t)
+		} else {
+			fmt.Fprintf(b, " + %s_%d", prefix, t)
+		}
+	}
+	fmt.Fprintf(b, " + %s %s %g\n", slack, op, rhs)
+}
+
+// parseCBCSolution reads CBC's `solu` output. The first line holds the status
+// (e.g. "Optimal - objective value 12.34"). Remaining lines hold per-variable
+// assignments: `<index> <name> <value> <reducedCost>`.
+func parseCBCSolution(path string, slots int) (*lpResult, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	res := &lpResult{schedule: make([]int, slots)}
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 1<<16)
+	scanner.Buffer(buf, 1<<20)
+	firstLine := true
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if firstLine {
+			firstLine = false
+			res.status = line
+			if !strings.HasPrefix(strings.ToLower(line), "optimal") {
+				return nil, fmt.Errorf("non-optimal status: %s", line)
+			}
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		name := fields[1]
+		val, err := strconv.ParseFloat(fields[2], 64)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(name, "x_") {
+			idx, err := strconv.Atoi(name[2:])
+			if err != nil || idx < 0 || idx >= slots {
+				continue
+			}
+			res.schedule[idx] = int(math.Round(val))
+		} else if name == "slack" {
+			res.slack = val
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/pool-pump-planner/milp_test.go
+++ b/pool-pump-planner/milp_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteLPRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "problem.lp")
+	in := lpInput{
+		costs:       []float64{1, 2, 3, 4},
+		blocked:     map[int]bool{1: true},
+		minSlots:    1,
+		targetSlots: 2,
+		maxSlots:    3,
+		maxStarts:   2,
+	}
+	if err := writeLP(path, in); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		"Minimize",
+		"obj:",
+		"slack",
+		"c_min:",
+		"c_target:",
+		"c_max:",
+		"c_maxstarts:",
+		"c_blk_1:",
+		"Binary",
+		"End",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("LP output missing %q\n%s", want, s)
+		}
+	}
+}
+
+func TestParseCBCSolution(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sol.txt")
+	content := "Optimal - objective value 10.5\n" +
+		"0 x_0 1 0\n" +
+		"1 x_1 0 0\n" +
+		"2 x_2 1 0\n" +
+		"3 slack 0.5 0\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := parseCBCSolution(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.schedule[0] != 1 || res.schedule[1] != 0 || res.schedule[2] != 1 {
+		t.Errorf("bad schedule: %v", res.schedule)
+	}
+	if res.slack != 0.5 {
+		t.Errorf("bad slack: %v", res.slack)
+	}
+}

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strings"
+	"time"
+)
+
+type planStats struct {
+	plannedHours    float64
+	expectedCostSEK float64
+	slackHours      float64
+	costPerSlot     []float64
+}
+
+func nan() float64 { return math.NaN() }
+
+// runPlanner is the top-level entry. Any error is logged so the caller can
+// keep running on a schedule without crashing.
+func runPlanner(cfg *Config) {
+	if err := plan(cfg); err != nil {
+		log.Printf("[planner] run failed: %v", err)
+	}
+}
+
+func plan(cfg *Config) error {
+	slotMinutes := cfg.SlotMinutes
+	horizonSlots := cfg.HorizonSlots()
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	slots := make([]time.Time, horizonSlots)
+	for i := 0; i < horizonSlots; i++ {
+		slots[i] = now.Add(time.Duration(i*slotMinutes) * time.Minute)
+	}
+
+	prices := cfg.fetchHourlyPrices(slots)
+	solar := cfg.fetchSolarForecast(slots)
+	waterTemp, waterOK := cfg.fetchWaterTemp()
+
+	missing := missingInputs(prices, waterOK, horizonSlots)
+	if missing != "" {
+		log.Printf("[planner] missing inputs %s, falling back to static schedule", missing)
+		sch := fallbackSchedule(cfg, slots)
+		stats := fallbackStats(cfg, sch, prices, solar)
+		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing)
+	}
+
+	targetHours := computeTargetHours(cfg, waterTemp, waterOK)
+	log.Printf("[planner] horizon=24h target_hours=%d water_temp=%.2f min=%d max=%d",
+		targetHours, waterTemp, cfg.MinHours, cfg.MaxHours)
+
+	sch, stats, err := solve(cfg, slots, prices, solar, targetHours)
+	if err != nil {
+		log.Printf("[planner] MILP failed: %v, falling back", err)
+		sch = fallbackSchedule(cfg, slots)
+		stats = fallbackStats(cfg, sch, prices, solar)
+		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible")
+	}
+	return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "")
+}
+
+func missingInputs(prices []float64, waterOK bool, want int) string {
+	missing := []string{}
+	if len(prices) < want {
+		missing = append(missing, "prices")
+	} else {
+		have := 0
+		for _, p := range prices {
+			if !math.IsNaN(p) {
+				have++
+			}
+		}
+		if have < want {
+			missing = append(missing, "prices")
+		}
+	}
+	if !waterOK {
+		missing = append(missing, "water_temp")
+	}
+	return strings.Join(missing, ",")
+}
+
+func computeTargetHours(cfg *Config, waterTemp float64, waterOK bool) int {
+	if !waterOK || cfg.HeatingRateCPerHour <= 0 {
+		return cfg.TargetHours
+	}
+	delta := cfg.TargetTempC - waterTemp
+	if delta < 0 {
+		delta = 0
+	}
+	needed := int(math.Ceil(delta / cfg.HeatingRateCPerHour))
+	if needed < cfg.TargetHours {
+		needed = cfg.TargetHours
+	}
+	if needed > cfg.MaxHours {
+		needed = cfg.MaxHours
+	}
+	return needed
+}
+
+func fallbackSchedule(cfg *Config, slots []time.Time) []int {
+	on := map[int]bool{}
+	for _, h := range cfg.FallbackNightHours {
+		on[h] = true
+	}
+	for _, h := range cfg.FallbackAfternoonHours {
+		on[h] = true
+	}
+	out := make([]int, len(slots))
+	for i, s := range slots {
+		if on[s.In(cfg.Timezone).Hour()] {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+func fallbackStats(cfg *Config, sch []int, prices []float64, solar []float64) planStats {
+	slotEnergy := cfg.PumpKW * cfg.SlotHours()
+	cps := make([]float64, len(sch))
+	total := 0.0
+	for t := range sch {
+		p := 0.0
+		if len(prices) > t && !math.IsNaN(prices[t]) {
+			p = prices[t]
+		}
+		s := 0.0
+		if len(solar) > t {
+			s = solar[t]
+		}
+		gridKWh := slotEnergy - s
+		if gridKWh < 0 {
+			gridKWh = 0
+		}
+		c := slotEnergy*p + gridKWh*cfg.GridFeeSEKPerKWh
+		cps[t] = c
+		if sch[t] == 1 {
+			total += c
+		}
+	}
+	totalSlots := 0
+	for _, v := range sch {
+		totalSlots += v
+	}
+	return planStats{
+		plannedHours:    float64(totalSlots) * cfg.SlotHours(),
+		expectedCostSEK: total,
+		slackHours:      0,
+		costPerSlot:     cps,
+	}
+}
+
+func solve(cfg *Config, slots []time.Time, prices, solar []float64, targetHours int) ([]int, planStats, error) {
+	T := cfg.HorizonSlots()
+	slotEnergy := cfg.PumpKW * cfg.SlotHours()
+
+	costs := make([]float64, T)
+	blocked := map[int]bool{}
+	blockedHourSet := map[int]bool{}
+	for _, h := range cfg.BlockedHours {
+		blockedHourSet[h] = true
+	}
+
+	for t := 0; t < T; t++ {
+		p := prices[t]
+		if math.IsNaN(p) {
+			costs[t] = 0
+			blocked[t] = true
+			continue
+		}
+		grid := slotEnergy - solar[t]
+		if grid < 0 {
+			grid = 0
+		}
+		costs[t] = slotEnergy*p + grid*cfg.GridFeeSEKPerKWh
+
+		if blockedHourSet[slots[t].In(cfg.Timezone).Hour()] {
+			blocked[t] = true
+		}
+	}
+
+	slotsPerHour := cfg.SlotsPerHour()
+	minSlots := cfg.MinHours * slotsPerHour
+	targetSlots := targetHours * slotsPerHour
+	maxSlots := cfg.MaxHours * slotsPerHour
+
+	available := 0
+	for t := 0; t < T; t++ {
+		if !blocked[t] {
+			available++
+		}
+	}
+	if available < minSlots {
+		return nil, planStats{}, fmt.Errorf("only %d available slots after blocking (need >= %d)", available, minSlots)
+	}
+	if maxSlots > available {
+		maxSlots = available
+	}
+
+	result, err := solveMILP(lpInput{
+		costs:       costs,
+		blocked:     blocked,
+		minSlots:    minSlots,
+		targetSlots: targetSlots,
+		maxSlots:    maxSlots,
+		maxStarts:   cfg.MaxStarts,
+	})
+	if err != nil {
+		return nil, planStats{}, err
+	}
+
+	total := 0.0
+	runSlots := 0
+	for t, on := range result.schedule {
+		if on == 1 {
+			total += costs[t]
+			runSlots++
+		}
+	}
+	stats := planStats{
+		plannedHours:    float64(runSlots) * cfg.SlotHours(),
+		expectedCostSEK: total,
+		slackHours:      result.slack * cfg.SlotHours(),
+		costPerSlot:     costs,
+	}
+	return result.schedule, stats, nil
+}
+
+func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+	waterTemp float64, waterOK bool, targetHours int, mode, missing string) error {
+	points := make([]*Point, 0, len(slots)+1)
+	for t, slot := range slots {
+		p := NewPoint("pool_iqpump_plan").
+			Tag("horizon", "24h").
+			Tag("mode", mode).
+			Field("on", sch[t]).
+			Field("cost_sek", stats.costPerSlot[t]).
+			At(slot)
+		priceField := 0.0
+		if len(prices) > t && !math.IsNaN(prices[t]) {
+			priceField = prices[t]
+		}
+		p.Field("price_sek_per_kwh", priceField)
+		solarField := 0.0
+		if len(solar) > t {
+			solarField = solar[t]
+		}
+		p.Field("solar_kwh", solarField)
+		points = append(points, p)
+	}
+
+	waterC := 0.0
+	if waterOK {
+		waterC = waterTemp
+	}
+
+	summary := NewPoint("pool_iqpump_plan_summary").
+		Tag("horizon", "24h").
+		Tag("mode", mode).
+		Field("planned_hours", stats.plannedHours).
+		Field("target_hours", targetHours).
+		Field("slot_minutes", cfg.SlotMinutes).
+		Field("expected_cost_sek", stats.expectedCostSEK).
+		Field("slack_hours", stats.slackHours).
+		Field("water_temp_c", waterC).
+		Field("missing_inputs", missing).
+		At(slots[0])
+	points = append(points, summary)
+
+	if err := cfg.WritePoints(points); err != nil {
+		return err
+	}
+	missingTag := missing
+	if missingTag == "" {
+		missingTag = "-"
+	}
+	log.Printf("[planner] plan written (mode=%s, slot=%dm): %.2f/%d hours, cost=%.2f SEK (slack=%.2f missing=%s)",
+		mode, cfg.SlotMinutes, stats.plannedHours, targetHours, stats.expectedCostSEK, stats.slackHours, missingTag)
+	return nil
+}

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -258,25 +258,29 @@ func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float6
 		waterC = waterTemp
 	}
 
+	// missing_inputs is a tag (not a field) because VictoriaMetrics drops
+	// string fields from InfluxDB line protocol. Values are low-cardinality:
+	// "none", "prices", "water_temp", "prices,water_temp", "infeasible".
+	missingTag := missing
+	if missingTag == "" {
+		missingTag = "none"
+	}
+
 	summary := NewPoint("pool_iqpump_plan_summary").
 		Tag("horizon", "24h").
 		Tag("mode", mode).
+		Tag("missing_inputs", missingTag).
 		Field("planned_hours", stats.plannedHours).
 		Field("target_hours", targetHours).
 		Field("slot_minutes", cfg.SlotMinutes).
 		Field("expected_cost_sek", stats.expectedCostSEK).
 		Field("slack_hours", stats.slackHours).
 		Field("water_temp_c", waterC).
-		Field("missing_inputs", missing).
 		At(slots[0])
 	points = append(points, summary)
 
 	if err := cfg.WritePoints(points); err != nil {
 		return err
-	}
-	missingTag := missing
-	if missingTag == "" {
-		missingTag = "-"
 	}
 	log.Printf("[planner] plan written (mode=%s, slot=%dm): %.2f/%d hours, cost=%.2f SEK (slack=%.2f missing=%s)",
 		mode, cfg.SlotMinutes, stats.plannedHours, targetHours, stats.expectedCostSEK, stats.slackHours, missingTag)

--- a/pool-pump-planner/solar.go
+++ b/pool-pump-planner/solar.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// fetchSolarForecast returns PV production (kWh) for each slot using
+// forecast.solar's period watt-hours endpoint. On error, returns zeros.
+func (c *Config) fetchSolarForecast(slots []time.Time) []float64 {
+	out := make([]float64, len(slots))
+	if c.GoogleLatLng == "" {
+		log.Printf("[planner] GOOGLE_LAT_LNG not set, skipping solar forecast")
+		return out
+	}
+	parts := strings.Split(c.GoogleLatLng, ",")
+	if len(parts) != 2 {
+		log.Printf("[planner] GOOGLE_LAT_LNG malformed: %q", c.GoogleLatLng)
+		return out
+	}
+	lat := strings.TrimSpace(parts[0])
+	lng := strings.TrimSpace(parts[1])
+	u := fmt.Sprintf(
+		"https://api.forecast.solar/estimate/watthours/period/%s/%s/%s/%s/%s",
+		lat, lng,
+		strconv.FormatFloat(c.PVDeclination, 'f', -1, 64),
+		strconv.FormatFloat(c.PVAzimuth, 'f', -1, 64),
+		strconv.FormatFloat(c.PVKWp, 'f', -1, 64),
+	)
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Get(u)
+	if err != nil {
+		log.Printf("[planner] forecast.solar fetch failed: %v", err)
+		return out
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		log.Printf("[planner] forecast.solar HTTP %d: %s", resp.StatusCode, string(body))
+		return out
+	}
+	var parsed struct {
+		Result map[string]any `json:"result"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		log.Printf("[planner] forecast.solar parse failed: %v", err)
+		return out
+	}
+	// Keys are naive site-local timestamps "YYYY-MM-DD HH:MM:SS". Bucket by hour.
+	byKey := make(map[string]float64)
+	for k, v := range parsed.Result {
+		t, err := time.ParseInLocation("2006-01-02 15:04:05", k, c.Timezone)
+		if err != nil {
+			continue
+		}
+		wh, ok := toFloat(v)
+		if !ok {
+			continue
+		}
+		key := t.Format("2006-01-02 15")
+		byKey[key] += wh / 1000.0
+	}
+	slotsPerHour := float64(c.SlotsPerHour())
+	for i, s := range slots {
+		key := s.In(c.Timezone).Format("2006-01-02 15")
+		out[i] = byKey[key] / slotsPerHour
+	}
+	return out
+}
+
+func toFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type promResponse struct {
+	Data struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []any             `json:"value"`
+			Values [][]any           `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func (c *Config) vmBaseURL() string {
+	if c.VMURL != "" {
+		u := strings.TrimRight(c.VMURL, "/")
+		if !strings.Contains(u, "://") {
+			u = "https://" + u
+		}
+		return u
+	}
+	if c.InfluxHost != "" {
+		if strings.Contains(c.InfluxHost, "://") {
+			return strings.TrimRight(c.InfluxHost, "/")
+		}
+		return "https://" + strings.TrimRight(c.InfluxHost, "/")
+	}
+	return ""
+}
+
+func (c *Config) queryPromInstant(promql, lookbackDelta string) ([]promResult, error) {
+	base := c.vmBaseURL()
+	if base == "" {
+		return nil, fmt.Errorf("VictoriaMetrics query URL not configured")
+	}
+	q := url.Values{}
+	q.Set("query", promql)
+	if lookbackDelta != "" {
+		q.Set("lookback_delta", lookbackDelta)
+	}
+	return c.promGet(base+"/api/v1/query?"+q.Encode(), false)
+}
+
+func (c *Config) queryPromRange(promql string, start, end time.Time, stepSeconds int) ([]promResult, error) {
+	base := c.vmBaseURL()
+	if base == "" {
+		return nil, fmt.Errorf("VictoriaMetrics query URL not configured")
+	}
+	q := url.Values{}
+	q.Set("query", promql)
+	q.Set("start", strconv.FormatInt(start.Unix(), 10))
+	q.Set("end", strconv.FormatInt(end.Unix(), 10))
+	q.Set("step", strconv.Itoa(stepSeconds))
+	return c.promGet(base+"/api/v1/query_range?"+q.Encode(), true)
+}
+
+type promResult struct {
+	Metric map[string]string
+	// For instant: single (ts, value). For range: many.
+	Values []promSample
+}
+
+type promSample struct {
+	Timestamp float64
+	Value     float64
+}
+
+func (c *Config) promGet(u string, rangeQuery bool) ([]promResult, error) {
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.VMToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.VMToken)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("vm query %d: %s", resp.StatusCode, string(body))
+	}
+	var pr promResponse
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return nil, fmt.Errorf("parse vm response: %w", err)
+	}
+	out := make([]promResult, 0, len(pr.Data.Result))
+	for _, r := range pr.Data.Result {
+		pr := promResult{Metric: r.Metric}
+		if rangeQuery {
+			for _, v := range r.Values {
+				if s, ok := parseSample(v); ok {
+					pr.Values = append(pr.Values, s)
+				}
+			}
+		} else if len(r.Value) == 2 {
+			if s, ok := parseSample(r.Value); ok {
+				pr.Values = append(pr.Values, s)
+			}
+		}
+		out = append(out, pr)
+	}
+	return out, nil
+}
+
+func parseSample(v []any) (promSample, bool) {
+	if len(v) != 2 {
+		return promSample{}, false
+	}
+	var ts float64
+	switch t := v[0].(type) {
+	case float64:
+		ts = t
+	case int64:
+		ts = float64(t)
+	default:
+		return promSample{}, false
+	}
+	var val float64
+	switch x := v[1].(type) {
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		if err != nil {
+			return promSample{}, false
+		}
+		val = f
+	case float64:
+		val = x
+	default:
+		return promSample{}, false
+	}
+	return promSample{Timestamp: ts, Value: val}, true
+}
+
+// fetchHourlyPrices returns one price per slot; slot prices inside the same
+// clock hour share the same hourly price. Returned slice has the same length
+// and order as slots; missing entries are NaN.
+func (c *Config) fetchHourlyPrices(slots []time.Time) []float64 {
+	out := make([]float64, len(slots))
+	for i := range out {
+		out[i] = nan()
+	}
+	if len(slots) == 0 {
+		return out
+	}
+	promql := fmt.Sprintf(`energy_price_SEK_per_kWh{area="%s"}`, c.PriceArea)
+	start := slots[0]
+	end := slots[len(slots)-1]
+	result, err := c.queryPromRange(promql, start, end, 3600)
+	if err != nil {
+		log.Printf("[planner] price query failed: %v", err)
+		return out
+	}
+	if len(result) == 0 {
+		result, err = c.queryPromRange(fmt.Sprintf(`energy_price{area="%s"}`, c.PriceArea), start, end, 3600)
+		if err != nil {
+			log.Printf("[planner] fallback price query failed: %v", err)
+			return out
+		}
+	}
+	if len(result) == 0 {
+		return out
+	}
+	byHour := make(map[int64]float64)
+	for _, s := range result[0].Values {
+		bucket := (int64(s.Timestamp) / 3600) * 3600
+		byHour[bucket] = s.Value
+	}
+	for i, s := range slots {
+		bucket := (s.Unix() / 3600) * 3600
+		if v, ok := byHour[bucket]; ok {
+			out[i] = v
+		}
+	}
+	return out
+}
+
+func (c *Config) fetchWaterTemp() (float64, bool) {
+	result, err := c.queryPromInstant("pool_temperatur_value", "")
+	if err != nil {
+		log.Printf("[planner] water temp query failed: %v", err)
+		return 0, false
+	}
+	if len(result) == 0 || len(result[0].Values) == 0 {
+		return 0, false
+	}
+	return result[0].Values[0].Value, true
+}

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -13,7 +13,10 @@ import (
 )
 
 type promResponse struct {
-	Data struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	Data      struct {
 		Result []struct {
 			Metric map[string]string `json:"metric"`
 			Value  []any             `json:"value"`
@@ -97,6 +100,12 @@ func (c *Config) promGet(u string, rangeQuery bool) ([]promResult, error) {
 	var pr promResponse
 	if err := json.Unmarshal(body, &pr); err != nil {
 		return nil, fmt.Errorf("parse vm response: %w", err)
+	}
+	// Prometheus-compatible APIs return 200 with status=error for query-side
+	// failures (bad PromQL, unknown metric, etc.) — surface those as errors
+	// instead of masking them as empty results.
+	if pr.Status != "" && pr.Status != "success" {
+		return nil, fmt.Errorf("vm query error (%s): %s", pr.ErrorType, pr.Error)
 	}
 	out := make([]promResult, 0, len(pr.Data.Result))
 	for _, r := range pr.Data.Result {


### PR DESCRIPTION
## Summary
- New standalone Go sidecar at `pool-pump-planner/` that re-implements the daily MILP planner from #299 in its own container.
- Same env surface as the Python planner (`POOL_*`, `INFLUX_*`, `INFLUXDB_V3_*`, `GOOGLE_LAT_LNG`) so it can share `fetcher-core/python/.env` directly.
- Writes the same `pool_iqpump_plan` (15-min slots) and `pool_iqpump_plan_summary` points, so existing Grafana panels + the Python actuator keep working.
- Solver is CBC (the same backend PuLP uses in Python) — the Go binary generates an LP file and shells out to `cbc`. Runtime image is `debian:bookworm-slim` + `coinor-cbc`.

## Scheduling
- On startup, plans once (mirrors `schedule.run_all(delay_seconds=10)`), then re-plans daily at `POOL_PLAN_TIME` (default `14:05` site-local, after tomorrow's Nord Pool prices publish).
- `--once` flag (or `once` subcommand) runs a single plan and exits, handy for cron or manual invocation.

## Docker / ops touches
- `docker-compose.yml`: new `pool-pump-planner` service pulling from GAR (`europe-docker.pkg.dev/.../pool-pump-planner:latest`), WUD-watched, depends on `database-auth`.
- `docker-compose.local.yml`: `container_name` + `env_file: ./fetcher-core/python/.env`.
- `docker-compose.dev.yml`: local `build: ./pool-pump-planner` for dev builds.
- Root `Makefile`: `build-pool-pump-planner` / `push-pool-pump-planner` targets in the same style as the fetcher / proxy images.

## Model parity with #299
- Objective `Σ (pump_kw · spot + max(0, pump_kw − solar) · grid_fee) · x_t + BigM · slack`
- Hard: `Σ x ≥ POOL_MIN_HOURS·slots_per_hour`, `Σ x ≤ POOL_MAX_HOURS·slots_per_hour`
- Soft: `Σ x + slack ≥ target_slots` (temp-derived if `POOL_HEATING_RATE_C_PER_HOUR > 0`)
- Anti-cycling: `y_t ≥ x_t − x_{t−1}`, `Σ y ≤ POOL_MAX_STARTS`
- Blocked peaks: `x_t = 0` for slots whose site-local hour is in `POOL_BLOCKED_HOURS`
- Same deterministic fallback (`POOL_FALLBACK_NIGHT_HOURS` ∪ `POOL_FALLBACK_AFTERNOON_HOURS`) when prices/water temp are missing or solver is infeasible.

## Test plan
- [ ] `make -C pool-pump-planner test` — vet + unit tests pass (LP builder / CBC solution parser).
- [ ] `make -C pool-pump-planner build` — Docker image builds with CBC installed.
- [ ] `docker run --rm --env-file fetcher-core/python/.env pool-pump-planner:latest --once` — produces 96 `pool_iqpump_plan` points + 1 summary in VM.
- [ ] Grafana panels for `pool_iqpump_plan{mode="optimal"}` render identical to the Python planner for the same day.
- [ ] Decide whether to disable the Python `pool_pump_planner` schedule in `fetcher-core/python/src/main.py` or run both for a bake-off.

https://claude.ai/code/session_01Pe7RMjJUiedeouLVPFBJx6