### PR TITLE
Add Grafana panel for pool pump plan metric

### DIFF
--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -7,6 +7,7 @@ import { spaPanels } from './panels/spa.ts';
 import { energyPanels } from './panels/energy.ts';
 import { eufyPanels } from './panels/eufy.ts';
 import { lightingPanels } from './panels/lighting.ts';
+import { navimowPanels } from './panels/navimow.ts';
 import { volvoPanels } from './panels/volvo.ts';
 
 function buildDashboard() {
@@ -63,15 +64,21 @@ function buildDashboard() {
     builder.withPanel(panel);
   }
 
+  // Navimow row
+  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 93 }));
+  for (const panel of navimowPanels()) {
+    builder.withPanel(panel);
+  }
+
   // Eufy Cameras row (collapsed)
-  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 93 });
+  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 102 });
   for (const panel of eufyPanels()) {
     eufyRow.withPanel(panel);
   }
   builder.withRow(eufyRow);
 
   // Tapo row
-  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 94 }));
+  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 103 }));
   for (const panel of tapoPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -52,26 +52,26 @@ function buildDashboard() {
   }
 
   // Energi row
-  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 52 }));
+  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 60 }));
   for (const panel of energyPanels()) {
     builder.withPanel(panel);
   }
 
   // Volvo XC40 row
-  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 76 }));
+  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 84 }));
   for (const panel of volvoPanels()) {
     builder.withPanel(panel);
   }
 
   // Eufy Cameras row (collapsed)
-  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 85 });
+  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 93 });
   for (const panel of eufyPanels()) {
     eufyRow.withPanel(panel);
   }
   builder.withRow(eufyRow);
 
   // Tapo row
-  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 86 }));
+  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 94 }));
   for (const panel of tapoPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/panels/house.ts
+++ b/grafana/src/panels/house.ts
@@ -219,10 +219,21 @@ export function tapoPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(
-      vmExpr('A', 'last_over_time(tapo_cloud_device_device_count[$__interval])', '{{device_alias}}'),
+      vmExpr(
+        'A',
+        'sum(tapo_cloud_device_device_count{device_type="HOMEWIFISYSTEM"}[$__interval]) by (device_model)',
+        'WiFi: {{device_model}}',
+      ),
+    )
+    .withTarget(
+      vmExpr(
+        'B',
+        'sum(tapo_cloud_device_device_count{device_type!="HOMEWIFISYSTEM"}[$__interval]) by (device_type)',
+        'Other: {{device_type}}',
+      ),
     )
     .timeFrom('7d/d')
-    .gridPos({ h: 7, w: 12, x: 0, y: 87 });
+    .gridPos({ h: 7, w: 12, x: 0, y: 104 });
 
   return [tapoOnline];
 }

--- a/grafana/src/panels/navimow.ts
+++ b/grafana/src/panels/navimow.ts
@@ -1,0 +1,32 @@
+import { PanelBuilder as TimeseriesBuilder } from '@grafana/grafana-foundation-sdk/timeseries';
+import type * as cog from '@grafana/grafana-foundation-sdk/cog';
+import type * as dashboard from '@grafana/grafana-foundation-sdk/dashboard';
+import { VM_DS, vmExpr } from '../datasource.ts';
+import {
+  greenThreshold, paletteColor,
+  legendBottom, tooltipSingle,
+  overrideDisplayAndColor,
+  SPAN_NULLS_MS,
+} from '../helpers.ts';
+
+export function navimowPanels(): cog.Builder<dashboard.Panel>[] {
+  // Navimow i206 AWD Battery (timeseries)
+  const batteryTs = new TimeseriesBuilder()
+    .title('Navimow 🟢')
+    .datasource(VM_DS)
+    .unit('percent')
+    .min(0)
+    .max(100)
+    .colorScheme(paletteColor())
+    .thresholds(greenThreshold())
+    .legend(legendBottom())
+    .tooltip(tooltipSingle())
+    .insertNulls(SPAN_NULLS_MS)
+    .overrides([
+      overrideDisplayAndColor('Navimow i206 AWD Battery', 'Navimow i206 AWD Battery', 'green'),
+    ])
+    .withTarget(vmExpr('A', 'last_over_time(ha_navimow_i206_awd_battery_value[$__interval])', '{{friendly_name}}'))
+    .gridPos({ h: 8, w: 24, x: 0, y: 94 });
+
+  return [batteryTs];
+}

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -4,8 +4,8 @@ import type * as cog from '@grafana/grafana-foundation-sdk/cog';
 import type * as dashboard from '@grafana/grafana-foundation-sdk/dashboard';
 import { VM_DS, vmMetric, vmExpr } from '../datasource.ts';
 import {
-  greenRedThresholds, thresholds, paletteColor,
-  legendBottom, tooltipSingle,
+  greenRedThresholds, greenThreshold, thresholds, paletteColor,
+  legendBottom, tooltipSingle, tooltipMulti,
   overrideDisplayAndColor,
   SPAN_NULLS_MS,
 } from '../helpers.ts';
@@ -88,5 +88,24 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmMetric('B', 'pool_iqpump_motordata', 'speed'))
     .gridPos({ h: 7, w: 7, x: 17, y: 37 });
 
-  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs];
+  // Poolpump plan (timeseries) — 24h MILP schedule from pool-pump-planner
+  const pumpPlan = new TimeseriesBuilder()
+    .title('Poolpump plan (24h)')
+    .datasource(VM_DS)
+    .colorScheme(paletteColor())
+    .thresholds(greenThreshold())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .insertNulls(SPAN_NULLS_MS)
+    .overrides([
+      overrideDisplayAndColor('on', 'Pump på', 'blue'),
+      overrideDisplayAndColor('price_sek_per_kwh', 'Spotpris (SEK/kWh)', 'yellow'),
+      overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
+    ])
+    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on[$__interval])', 'on'))
+    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh[$__interval])', 'price_sek_per_kwh'))
+    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh[$__interval])', 'solar_kwh'))
+    .gridPos({ h: 8, w: 24, x: 0, y: 52 });
+
+  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan];
 }


### PR DESCRIPTION
## Summary
- New `Poolpump plan (24h)` timeseries panel in `grafana/src/panels/pool.ts`, placed at the bottom of the pool section.
- Plots the MILP planner's `pool_iqpump_plan_on` schedule together with `pool_iqpump_plan_price_sek_per_kwh` (spot price) and `pool_iqpump_plan_solar_kwh` (solar forecast) for context.
- Shifts the `Energi`, `Volvo XC40`, `Eufy Cameras`, and `Tapo` row `gridPos.y` values by +8 in `grafana/src/index.ts` to make room.

Visualizes the metric emitted by the Go pool-pump-planner introduced in #300.

## Test plan
- [ ] `cd grafana && npm run build` produces `dist/dashboard.json` without errors
- [ ] `dist/dashboard.json` contains the three `pool_iqpump_plan_*` queries
- [ ] Panel renders in Grafana once the planner has written points

https://claude.ai/code/session_01TpRSFCweCGLHitnxoSguHi