### PR TITLE
Fix empty Volvo XC40 row (panels absorbed into Energi)

### DIFF
--- a/grafana/src/panels/volvo.ts
+++ b/grafana/src/panels/volvo.ts
@@ -33,7 +33,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('B', 'last_over_time(ha_xc40_state_of_charge[$__interval])', 'soc'))
     .withTarget(vmExpr('C', 'last_over_time(ha_xc40_target_state_of_charge[$__interval])', 'target_soc'))
     .withTarget(vmExpr('D', 'last_over_time(ha_volvo_xc40_target_battery_charge_level_value[$__interval])', 'target_charge'))
-    .gridPos({ h: 8, w: 12, x: 0, y: 77 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 85 });
 
   // ⚡ XC40 Laddeffekt (timeseries) - charging power
   const chargingTs = new TimeseriesBuilder()
@@ -47,7 +47,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_charging_power_value[$__interval])', 'Laddeffekt'))
-    .gridPos({ h: 8, w: 6, x: 12, y: 77 });
+    .gridPos({ h: 8, w: 6, x: 12, y: 85 });
 
   // 🛣️ Räckvidd (stat) - distance to empty battery
   const distanceStat = new StatBuilder()
@@ -62,7 +62,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 100 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_distance_to_empty_battery_value[$__interval])', 'Räckvidd'))
-    .gridPos({ h: 8, w: 3, x: 18, y: 77 });
+    .gridPos({ h: 8, w: 3, x: 18, y: 85 });
 
   // 🔧 Service (stat) - time to service
   const serviceStat = new StatBuilder()
@@ -76,7 +76,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 90 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_time_to_service_value[$__interval])', 'Service'))
-    .gridPos({ h: 8, w: 3, x: 21, y: 77 });
+    .gridPos({ h: 8, w: 3, x: 21, y: 85 });
 
   return [batteryTs, chargingTs, distanceStat, serviceStat];
 }


### PR DESCRIPTION
## Summary
- The row shift in #307 moved the `Volvo XC40` row to `y=84` but left the four Volvo panels at `y=77`, so Grafana sorted them into the preceding `Energi` row and the Volvo row rendered empty.
- Moves all four Volvo panels to `y=85` (just below the row header).

## Test plan
- [ ] `cd grafana && npm run build` and confirm the Volvo panels now belong to the `Volvo XC40` row.

https://claude.ai/code/session_01TpRSFCweCGLHitnxoSguHi