### PR TITLE
Update @grafana/grafana-foundation-sdk to latest (0.0.12)

### DIFF
--- a/grafana/package-lock.json
+++ b/grafana/package-lock.json
@@ -8,7 +8,7 @@
       "name": "iot-fetcher-grafana",
       "version": "1.0.0",
       "dependencies": {
-        "@grafana/grafana-foundation-sdk": "~11.6.0-cogv0.0.x.1769699379"
+        "@grafana/grafana-foundation-sdk": "^0.0.12"
       },
       "devDependencies": {
         "@types/node": "^25.2.0"
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@grafana/grafana-foundation-sdk": {
-      "version": "11.6.0-cogv0.0.x.1769699379",
-      "resolved": "https://registry.npmjs.org/@grafana/grafana-foundation-sdk/-/grafana-foundation-sdk-11.6.0-cogv0.0.x.1769699379.tgz",
-      "integrity": "sha512-kCE8BenAAOjFC5baHIPWy9lepzs6Z7GgJ0FoBO0ZNxBnNuka0VTEV18UX9DLMXcfSrITqY3yzwkq0L0E/Sf61g==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@grafana/grafana-foundation-sdk/-/grafana-foundation-sdk-0.0.12.tgz",
+      "integrity": "sha512-9OXNTXblkwV9o0ToQtXd4GzUG5CmeMvUxTRVge2Xrws7+W/Ytc7fNF80Xs4vnEDRFBOIw7psZIJXpVHDVxVQaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/grafana/package-lock.json
+++ b/grafana/package-lock.json
@@ -8,7 +8,7 @@
       "name": "iot-fetcher-grafana",
       "version": "1.0.0",
       "dependencies": {
-        "@grafana/grafana-foundation-sdk": "^0.0.12"
+        "@grafana/grafana-foundation-sdk": "~0.0.12"
       },
       "devDependencies": {
         "@types/node": "^25.2.0"

--- a/grafana/package.json
+++ b/grafana/package.json
@@ -10,7 +10,7 @@
     "node": ">=25.0.0"
   },
   "dependencies": {
-    "@grafana/grafana-foundation-sdk": "~11.6.0-cogv0.0.x.1769699379"
+    "@grafana/grafana-foundation-sdk": "^0.0.12"
   },
   "devDependencies": {
     "@types/node": "^25.2.0"

--- a/grafana/package.json
+++ b/grafana/package.json
@@ -10,7 +10,7 @@
     "node": ">=25.0.0"
   },
   "dependencies": {
-    "@grafana/grafana-foundation-sdk": "^0.0.12"
+    "@grafana/grafana-foundation-sdk": "~0.0.12"
   },
   "devDependencies": {
     "@types/node": "^25.2.0"


### PR DESCRIPTION
## Summary
- Bump `@grafana/grafana-foundation-sdk` from `~11.6.0-cogv0.0.x.1769699379` to `^0.0.12` (upstream switched to a new versioning scheme; `0.0.12` is the current `latest` dist-tag).
- Build succeeds; the generated `dashboard.json` is byte-identical to the previous output except `schemaVersion` bumps from `41` → `42`.

## Test plan
- [x] `npm install` resolves cleanly
- [x] `npm run build` (GRAFANA_SKIP_UPLOAD=1) produces `dist/dashboard.json`
- [x] Diff vs previous output: only `schemaVersion` changed
- [ ] Verify the regenerated dashboard loads in Grafana after upload

https://claude.ai/code/session_01JDRWzVfNKx1JyUAfdw5dDB