### PR TITLE
fix(pool-pump-planner): use dedicated env file

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -25,7 +25,7 @@ services:
 
   pool-pump-planner:
     container_name: pool-pump-planner
-    env_file: ./fetcher-core/python/.env
+    env_file: ./pool-pump-planner/.env
 
   tibber-influx-bridge:
     container_name: tibber-influxdb-bridge


### PR DESCRIPTION
## Summary
- Switch `pool-pump-planner` from sharing `fetcher-core/python/.env` to its own `pool-pump-planner/.env`.
- Lets us add planner-specific `POOL_*` overrides without polluting the shared fetcher-core env.
- The new file is gitignored via the repo-root `.env` rule; it has already been created on rpi5 as a copy of `fetcher-core/python/.env` (identical bytes), so functional behavior is unchanged after the compose cutover.

## Test plan
- [ ] Pull on rpi5 and bring the stack up:
  - `ssh rpi5 "cd ~/iot-fetcher && git pull && sudo docker compose -f docker-compose.yml -f docker-compose.local.yml up -d pool-pump-planner"`
- [ ] Confirm the planner connects to VictoriaMetrics and writes a plan:
  - `ssh rpi5 "sudo docker logs --tail 20 pool-pump-planner"` should show `[influx] wrote N points (pool_iqpump_plan ...)` with no `connection refused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)