### PR TITLE
fix(pool-pump-planner): correct pool_temperature_value metric name

### DIFF
--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -199,7 +199,7 @@ func (c *Config) fetchHourlyPrices(slots []time.Time) []float64 {
 }
 
 func (c *Config) fetchWaterTemp() (float64, bool) {
-	result, err := c.queryPromInstant("pool_temperatur_value", "")
+	result, err := c.queryPromInstant("pool_temperature_value", "")
 	if err != nil {
 		log.Printf("[planner] water temp query failed: %v", err)
 		return 0, false


### PR DESCRIPTION
Fixes a typo in pool-pump-planner/vm.go where fetchWaterTemp queried the misspelled metric pool_temperatur_value. VictoriaMetrics exposes pool_temperature_value, verified against the live VM catalog on rpi5. The bug caused empty results and the planner falling back to the static schedule with the log line 'missing inputs prices,water_temp'. Test plan: go test ./pool-pump-planner/... (Go toolchain unavailable in sandbox); post-merge deploy to rpi5 and tail planner logs to confirm the fallback warning disappears.