### PR TITLE
feat(pool-pump-planner): model SE4 taxes and transfer fee

### DIFF
--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -24,8 +24,14 @@ type Config struct {
 	PVKWp         float64
 
 	// Pump
-	PumpKW            float64
-	GridFeeSEKPerKWh  float64
+	PumpKW float64
+
+	// Swedish electricity costs. Transfer fee and energy tax are billed only
+	// on grid-imported energy; VAT is applied on top of the whole bill
+	// (including the energy tax, per Skatteverket's "skatt på skatt" rule).
+	TransferFeeSEKPerKWh float64 // elöverföring, per-kWh variable transfer fee, excl VAT
+	EnergyTaxSEKPerKWh   float64 // energiskatt, excl VAT
+	VATFraction          float64 // moms, e.g. 0.25 for 25%
 
 	// Scheduling
 	MinHours     int
@@ -65,8 +71,12 @@ func loadConfig() *Config {
 		PVAzimuth:     getenvFloat("POOL_PV_AZIMUTH", 0),
 		PVKWp:         getenvFloat("POOL_PV_KWP", 3.0),
 
-		PumpKW:           getenvFloat("POOL_PUMP_KW", 4.0),
-		GridFeeSEKPerKWh: getenvFloat("POOL_GRID_FEE_SEK_PER_KWH", 0.80),
+		PumpKW: getenvFloat("POOL_PUMP_KW", 4.0),
+
+		// Defaults calibrated to user's March 2026 E.ON invoice (SE4/MMO Malmö).
+		TransferFeeSEKPerKWh: getenvFloat("POOL_TRANSFER_FEE_SEK_PER_KWH", 0.2584),
+		EnergyTaxSEKPerKWh:   getenvFloat("POOL_ENERGY_TAX_SEK_PER_KWH", 0.36),
+		VATFraction:          getenvFloat("POOL_VAT_FRACTION", 0.25),
 
 		MinHours:     getenvInt("POOL_MIN_HOURS", 4),
 		TargetHours:  getenvInt("POOL_TARGET_HOURS", 6),

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -132,6 +132,24 @@ func fallbackSchedule(cfg *Config, slots []time.Time) []int {
 	return out
 }
 
+// slotCost is the marginal SEK cost of running the pump for one slot.
+// Spot price is charged on full consumption (opportunity cost of self-consumed
+// solar — the pump could otherwise be off and the energy used/sold elsewhere).
+// Transfer fee and energy tax are charged only on grid-imported kWh. VAT is
+// applied to the entire bill (Sweden charges moms on the energiskatt too).
+//
+// TODO: sell-back revenue. The real opportunity cost of self-consumed solar
+// is the nätnytta export credit (~12.48 öre/kWh on the user's invoice), not
+// full spot. Charging spot here overstates the cost of solar runs.
+func slotCost(cfg *Config, slotEnergy, p, solarKWh float64) float64 {
+	grid := slotEnergy - solarKWh
+	if grid < 0 {
+		grid = 0
+	}
+	pre := slotEnergy*p + grid*(cfg.TransferFeeSEKPerKWh+cfg.EnergyTaxSEKPerKWh)
+	return pre * (1 + cfg.VATFraction)
+}
+
 func fallbackStats(cfg *Config, sch []int, prices []float64, solar []float64) planStats {
 	slotEnergy := cfg.PumpKW * cfg.SlotHours()
 	cps := make([]float64, len(sch))
@@ -145,11 +163,7 @@ func fallbackStats(cfg *Config, sch []int, prices []float64, solar []float64) pl
 		if len(solar) > t {
 			s = solar[t]
 		}
-		gridKWh := slotEnergy - s
-		if gridKWh < 0 {
-			gridKWh = 0
-		}
-		c := slotEnergy*p + gridKWh*cfg.GridFeeSEKPerKWh
+		c := slotCost(cfg, slotEnergy, p, s)
 		cps[t] = c
 		if sch[t] == 1 {
 			total += c
@@ -185,11 +199,7 @@ func solve(cfg *Config, slots []time.Time, prices, solar []float64, targetHours 
 			blocked[t] = true
 			continue
 		}
-		grid := slotEnergy - solar[t]
-		if grid < 0 {
-			grid = 0
-		}
-		costs[t] = slotEnergy*p + grid*cfg.GridFeeSEKPerKWh
+		costs[t] = slotCost(cfg, slotEnergy, p, solar[t])
 
 		if blockedHourSet[slots[t].In(cfg.Timezone).Hour()] {
 			blocked[t] = true

--- a/pool-pump-planner/planner_test.go
+++ b/pool-pump-planner/planner_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSlotCost(t *testing.T) {
+	cfg := &Config{
+		TransferFeeSEKPerKWh: 0.2584,
+		EnergyTaxSEKPerKWh:   0.36,
+		VATFraction:          0.25,
+	}
+
+	tests := []struct {
+		name       string
+		slotEnergy float64
+		price      float64
+		solar      float64
+		want       float64
+	}{
+		{
+			// 1 kWh slot @ 0.5 SEK spot, no solar → full grid import.
+			// (0.5 + 0.2584 + 0.36) × 1.25 = 1.398.
+			name:       "no solar, full grid import",
+			slotEnergy: 1.0,
+			price:      0.5,
+			solar:      0.0,
+			want:       1.398,
+		},
+		{
+			// Solar covers the whole slot → no transfer/tax, only opportunity-
+			// cost of spot on consumption. 0.5 × 1.25 = 0.625.
+			name:       "solar covers full slot",
+			slotEnergy: 1.0,
+			price:      0.5,
+			solar:      1.0,
+			want:       0.625,
+		},
+		{
+			// Partial solar (0.6 kWh of 1.0): grid = 0.4.
+			// pre = 1.0×0.5 + 0.4×(0.2584+0.36) = 0.5 + 0.24736 = 0.74736.
+			// cost = 0.74736 × 1.25 = 0.9342.
+			name:       "partial solar",
+			slotEnergy: 1.0,
+			price:      0.5,
+			solar:      0.6,
+			want:       0.9342,
+		},
+		{
+			// Solar exceeds slot energy (exporting). Grid clamps to 0.
+			// 1.0×0.5 × 1.25 = 0.625, same as "solar covers full slot".
+			name:       "solar exceeds consumption",
+			slotEnergy: 1.0,
+			price:      0.5,
+			solar:      1.5,
+			want:       0.625,
+		},
+		{
+			// Real-slot hand check from the plan doc: 12:00 today, 15-min
+			// slot, pumpKW=4 → slotEnergy=1.0, p=0.1807, solar=0.629.
+			// grid = 0.371
+			// pre = 1.0×0.1807 + 0.371×(0.2584+0.36) = 0.1807 + 0.2294264 = 0.4101264.
+			// cost = 0.4101264 × 1.25 = 0.5126580.
+			name:       "plan doc hand-check at 12:00",
+			slotEnergy: 1.0,
+			price:      0.1807,
+			solar:      0.629,
+			want:       0.512658,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := slotCost(cfg, tc.slotEnergy, tc.price, tc.solar)
+			if math.Abs(got-tc.want) > 1e-4 {
+				t.Errorf("slotCost(%.4f, %.4f, %.4f) = %.6f, want %.6f",
+					tc.slotEnergy, tc.price, tc.solar, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Replace the flat `POOL_GRID_FEE_SEK_PER_KWH` (0.80 lump, no VAT) with three tax-aware vars that mirror how Swedish electricity is actually billed — transfer fee and energy tax on grid-imported kWh only, VAT on the whole bill incl. the tax ("skatt på skatt").

Defaults match the user's March 2026 E.ON invoice (SE4/MMO Malmö):

| Env | Default | Meaning |
|---|---|---|
| `POOL_TRANSFER_FEE_SEK_PER_KWH` | 0.2584 | Elöverföring excl VAT |
| `POOL_ENERGY_TAX_SEK_PER_KWH` | 0.36 | Energiskatt 2026 standard rate |
| `POOL_VAT_FRACTION` | 0.25 | Moms |

New `slotCost` helper is shared between `solve()` and `fallbackStats()` so the formula lives in one place and can be unit-tested without cbc.

## MILP behavior
- `EnergyTax × slotEnergy` is constant per slot → no ordering effect
- `TransferFee × grid` varies with solar → correctly tilts MILP toward sunny slots
- VAT is a uniform scale → no ordering effect

Dry-run at 08:55 CEST today: same 11:00–16:45 ON window as before, cost **12.86 SEK vs 12.02 SEK** pre-change (VAT on spot > savings from fee going 0.80 → 0.62).

## Follow-ups (not in this PR)
- Sell-back / nätnytta revenue: user's invoice shows exported solar compensated at 12.48 öre/kWh VAT-exempt. Charging full spot as opportunity cost overstates solar-run cost. TODO comment added in `slotCost`.
- Elhandelsavgift (retailer markup on spot): ~3–5 öre/kWh, not on the E.ON distribution invoice.

## Test plan
- [x] Local: `go test ./...` — new `TestSlotCost` (5 cases incl. hand-check) + existing MILP tests pass.
- [x] Local dry-run with `make run-local` — `mode=optimal, cost=12.86 SEK, missing=none`.
- [ ] On rpi5 after merge + redeploy:
  - Add `POOL_TRANSFER_FEE_SEK_PER_KWH`, `POOL_ENERGY_TAX_SEK_PER_KWH`, `POOL_VAT_FRACTION` to `~/iot-fetcher/pool-pump-planner/.env` (or rely on defaults).
  - `git pull && sudo docker compose -f docker-compose.yml -f docker-compose.local.yml up -d pool-pump-planner`.
  - Check `sudo docker logs` for `mode=optimal` + compare `pool_iqpump_plan_summary.expected_cost_sek` in Grafana — should be ~7% higher than pre-change (VAT now included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)