### PR TITLE
ci: add actionlint and optimize lockfile check

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,32 @@
+name: actionlint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download and verify actionlint
+        env:
+          VERSION: 1.7.12
+          SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          echo "${SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -3,6 +3,12 @@ name: Lock file check
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/pyproject.toml'
+      - '**/uv.lock'
+      - '.github/workflows/lockfile-check.yml'
 
 jobs:
   check-lockfiles:
@@ -27,12 +33,17 @@ jobs:
         if: matrix.type == 'node'
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: ${{ matrix.dir }}/package-lock.json
       - name: Verify npm lock file
         if: matrix.type == 'node'
         working-directory: ${{ matrix.dir }}
         run: npm ci
       - uses: astral-sh/setup-uv@v7
         if: matrix.type == 'python'
+        with:
+          enable-cache: true
+          cache-dependency-glob: ${{ matrix.dir }}/uv.lock
       - name: Verify uv lock file
         if: matrix.type == 'python'
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
## Summary
- Adds `actionlint` workflow pinned to v1.7.12 with SHA256 verification of the downloaded release binary (no third-party action dependency).
- Gates the lockfile check on manifest/lock path changes and enables npm/uv caching via `setup-node` and `setup-uv`.

## Why
Follow-up to #315. Catches workflow YAML issues locally in CI (parsing, invalid expressions, unknown action versions, shellcheck on `run:`), and avoids re-running the full lockfile matrix on every PR.

## Test plan
- [x] `actionlint` passes locally on all workflows
- [ ] `actionlint` job runs and passes on this PR
- [ ] Merging a PR that only touches, e.g., `ai-assistant/package.json` still triggers lockfile check
- [ ] Merging a PR with no lockfile/manifest changes skips the lockfile check