### PR TITLE
feat(scripts): add vm-shape.sh for per-metric shape summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,11 @@
 - Build Docker images locally and push to registry — don't build on rpi5
 
 # VictoriaMetrics
-- Credentials live in `fetcher-core/python/.env.local` — `INFLUX_HOST` (full URL incl. scheme, e.g. `http://host:port`) and `INFLUX_TOKEN`.
-- Auth header: `Authorization: Bearer $INFLUX_TOKEN`
-- List all metric names: `curl -s "$INFLUX_HOST/api/v1/label/__name__/values" -H "Authorization: Bearer $INFLUX_TOKEN"`
-- List label names: `curl -s "$INFLUX_HOST/api/v1/labels" -H "Authorization: Bearer $INFLUX_TOKEN"`
-- List values for a label: `curl -s "$INFLUX_HOST/api/v1/label/<label>/values" -H "Authorization: Bearer $INFLUX_TOKEN"`
-- Query a metric: `curl -s "$INFLUX_HOST/api/v1/query?query=<metric_name>" -H "Authorization: Bearer $INFLUX_TOKEN"`
-- For a per-metric shape summary (label keys + cardinality + latest sample), run `scripts/vm-shape.sh [pattern]` — resolves the repo root (worktree-safe), reads `.env.local`, and prints a Markdown table to stdout.
+**When you need to know what metrics exist or what shape they have, run `scripts/vm-shape.sh [pattern]` first — don't hand-write curl.** It resolves the repo root (worktree-safe), loads creds from `fetcher-core/python/.env.local`, and prints a Markdown table of metric names, label keys with cardinality, and the latest sample value/timestamp. Use a substring filter (e.g. `scripts/vm-shape.sh tibber`) to keep the output small.
+
+**For PromQL queries (instant or range), use `scripts/vm-query.sh`** — `vm-query.sh metrics|labels|label <name>|query <promql>|range <promql>`. Don't reinvent these with curl.
+
+Raw API is only for things the scripts above don't cover. Credentials: `INFLUX_HOST` (full URL incl. scheme) and `INFLUX_TOKEN` in `fetcher-core/python/.env.local`; auth header `Authorization: Bearer $INFLUX_TOKEN`. Endpoints: `/api/v1/label/__name__/values`, `/api/v1/labels`, `/api/v1/label/<name>/values`, `/api/v1/query`, `/api/v1/query_range`.
 
 # Deployment (rpi5)
 - The remote directory on rpi5 is `~/iot-fetcher` (hyphen, NOT underscore). The local directory uses an underscore but the remote uses a hyphen — never create `~/iot_fetcher` on rpi5.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@
 - Build Docker images locally and push to registry — don't build on rpi5
 
 # VictoriaMetrics
-- Tokens and credentials (InfluxDB/VictoriaMetrics, Grafana, etc.) are in `fetcher-core/python/.env`
-- The metrics backend is VictoriaMetrics, accessible at `https://$INFLUXDB_V3_URL`
-- Auth: `Authorization: Bearer $INFLUXDB_V3_ACCESS_TOKEN`
-- List all metric names: `curl -s "https://$INFLUXDB_V3_URL/api/v1/label/__name__/values" -H "Authorization: Bearer $INFLUXDB_V3_ACCESS_TOKEN"`
-- List label names: `curl -s "https://$INFLUXDB_V3_URL/api/v1/labels" -H "Authorization: Bearer $INFLUXDB_V3_ACCESS_TOKEN"`
-- List values for a label: `curl -s "https://$INFLUXDB_V3_URL/api/v1/label/<label>/values" -H "Authorization: Bearer $INFLUXDB_V3_ACCESS_TOKEN"`
-- Query a metric: `curl -s "https://$INFLUXDB_V3_URL/api/v1/query?query=<metric_name>" -H "Authorization: Bearer $INFLUXDB_V3_ACCESS_TOKEN"`
+- Credentials live in `fetcher-core/python/.env.local` — `INFLUX_HOST` (full URL incl. scheme, e.g. `http://host:port`) and `INFLUX_TOKEN`.
+- Auth header: `Authorization: Bearer $INFLUX_TOKEN`
+- List all metric names: `curl -s "$INFLUX_HOST/api/v1/label/__name__/values" -H "Authorization: Bearer $INFLUX_TOKEN"`
+- List label names: `curl -s "$INFLUX_HOST/api/v1/labels" -H "Authorization: Bearer $INFLUX_TOKEN"`
+- List values for a label: `curl -s "$INFLUX_HOST/api/v1/label/<label>/values" -H "Authorization: Bearer $INFLUX_TOKEN"`
+- Query a metric: `curl -s "$INFLUX_HOST/api/v1/query?query=<metric_name>" -H "Authorization: Bearer $INFLUX_TOKEN"`
+- For a per-metric shape summary (label keys + cardinality + latest sample), run `scripts/vm-shape.sh [pattern]` — resolves the repo root (worktree-safe), reads `.env.local`, and prints a Markdown table to stdout.
 
 # Deployment (rpi5)
 - The remote directory on rpi5 is `~/iot-fetcher` (hyphen, NOT underscore). The local directory uses an underscore but the remote uses a hyphen — never create `~/iot_fetcher` on rpi5.

--- a/scripts/vm-shape.sh
+++ b/scripts/vm-shape.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the main repo root even when invoked from a worktree — the common
+# .git dir is shared across all worktrees of a repo, so its parent is the
+# canonical checkout that holds fetcher-core/python/.env.local.
+GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+
+ENV_FILE="$REPO_ROOT/fetcher-core/python/.env.local"
+[[ -f "$ENV_FILE" ]] || { echo "Missing $ENV_FILE" >&2; exit 1; }
+
+for bin in curl jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "Missing required binary: $bin" >&2; exit 1; }
+done
+
+INFLUX_HOST="$(grep -E '^INFLUX_HOST=' "$ENV_FILE" | cut -d'=' -f2-)"
+INFLUX_TOKEN="$(grep -E '^INFLUX_TOKEN=' "$ENV_FILE" | cut -d'=' -f2-)"
+[[ -n "$INFLUX_HOST" && -n "$INFLUX_TOKEN" ]] \
+  || { echo "INFLUX_HOST / INFLUX_TOKEN missing in $ENV_FILE" >&2; exit 1; }
+
+BASE_URL="${INFLUX_HOST%/}"
+AUTH_HEADER="Authorization: Bearer ${INFLUX_TOKEN}"
+
+PATTERN="${1:-}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [pattern]
+
+  pattern   Optional substring; only metrics whose name contains it are inspected.
+
+Examples:
+  $(basename "$0")                  # all metrics
+  $(basename "$0") tibber           # only metrics containing "tibber"
+EOF
+  exit 1
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+# Fetch all metric names.
+METRICS_JSON="$(curl -sf "${BASE_URL}/api/v1/label/__name__/values" -H "$AUTH_HEADER")" \
+  || { echo "Failed to list metrics from $BASE_URL" >&2; exit 1; }
+
+if [[ -n "$PATTERN" ]]; then
+  mapfile -t METRICS < <(jq -r --arg p "$PATTERN" '.data[] | select(contains($p))' <<<"$METRICS_JSON")
+else
+  mapfile -t METRICS < <(jq -r '.data[]' <<<"$METRICS_JSON")
+fi
+
+TOTAL=${#METRICS[@]}
+echo "# Inspecting $TOTAL metric(s) from $BASE_URL${PATTERN:+ (filter: \"$PATTERN\")}" >&2
+
+printf '| metric | labels (cardinality) | latest value | last seen |\n'
+printf '|---|---|---|---|\n'
+
+iso_from_epoch() {
+  # Portable: macOS `date -r <epoch>`; GNU `date -d @<epoch>`.
+  local epoch="$1"
+  date -u -r "${epoch%.*}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@${epoch%.*}" +%Y-%m-%dT%H:%M:%SZ
+}
+
+urlencode_match() {
+  # Produce the already-encoded value for `match[]={__name__="<metric>"}`.
+  local metric="$1"
+  printf 'match%%5B%%5D=%%7B__name__%%3D%%22%s%%22%%7D' "$metric"
+}
+
+i=0
+for M in "${METRICS[@]}"; do
+  i=$((i + 1))
+  printf '# %d/%d %s\n' "$i" "$TOTAL" "$M" >&2
+
+  match="$(urlencode_match "$M")"
+
+  labels_json="$(curl -sf "${BASE_URL}/api/v1/labels?${match}" -H "$AUTH_HEADER")" || {
+    printf '| %s | (error) | (error) | — |\n' "$M"
+    continue
+  }
+  mapfile -t label_keys < <(jq -r '.data[] | select(. != "__name__")' <<<"$labels_json")
+
+  label_parts=()
+  for L in "${label_keys[@]}"; do
+    lv_json="$(curl -sf "${BASE_URL}/api/v1/label/${L}/values?${match}" -H "$AUTH_HEADER")" || {
+      label_parts+=("${L}(?)")
+      continue
+    }
+    count="$(jq '.data | length' <<<"$lv_json")"
+    label_parts+=("${L}(${count})")
+  done
+  labels_cell="$(IFS=', '; echo "${label_parts[*]:-—}")"
+
+  q_json="$(curl -sf -G "${BASE_URL}/api/v1/query" \
+    --data-urlencode "query=${M}" \
+    -H "$AUTH_HEADER")" || {
+    printf '| %s | %s | (error) | — |\n' "$M" "$labels_cell"
+    continue
+  }
+  first="$(jq -c '.data.result[0] // empty' <<<"$q_json")"
+
+  if [[ -z "$first" ]]; then
+    q_json="$(curl -sf -G "${BASE_URL}/api/v1/query" \
+      --data-urlencode "query=last_over_time(${M}[1d])" \
+      -H "$AUTH_HEADER")" || q_json='{}'
+    first="$(jq -c '.data.result[0] // empty' <<<"$q_json")"
+  fi
+
+  if [[ -z "$first" ]]; then
+    printf '| %s | %s | (stale) | — |\n' "$M" "$labels_cell"
+    continue
+  fi
+
+  ts="$(jq -r '.value[0]' <<<"$first")"
+  val="$(jq -r '.value[1]' <<<"$first")"
+  iso="$(iso_from_epoch "$ts")"
+
+  printf '| %s | %s | %s | %s |\n' "$M" "$labels_cell" "$val" "$iso"
+done


### PR DESCRIPTION
## Summary
- New `scripts/vm-shape.sh` — lists VictoriaMetrics metrics with their label keys, per-label cardinality, and latest sample value/timestamp, as a Markdown table.
- Worktree-safe: resolves the canonical repo root via `git rev-parse --git-common-dir`, so the script finds `fetcher-core/python/.env.local` no matter which worktree it's invoked from.
- Strict env loading: `grep`-extracts only `INFLUX_HOST` and `INFLUX_TOKEN` from `.env.local` (no `source`, so unrelated secrets in that file never enter the shell env).
- `CLAUDE.md`: corrects stale env-var names (`INFLUXDB_V3_URL` / `INFLUXDB_V3_ACCESS_TOKEN` → `INFLUX_HOST` / `INFLUX_TOKEN`), updates the four `curl` examples to match, and adds a pointer to the new script.

## Reviewer notes
- Progress goes to stderr (`# i/N metric`) so stdout stays a clean Markdown table that can be piped or pasted.
- For each metric: one call to `/api/v1/labels?match[]=…` for label keys, one `/api/v1/label/<L>/values?match[]=…` per label for cardinality, and one instant `/api/v1/query` for the latest sample (falling back to `last_over_time(metric[1d])` if empty, else `(stale)`).
- Curl/jq presence is checked up front; per-metric failures emit an `(error)` row and continue.
- `INFLUX_HOST` already includes the scheme (`http://…`), so the script uses it as the base URL directly — no HTTPS proxy round-trip (unlike `vm-query.sh`, which composes `PROXY_DOMAIN` from `https-proxy/.env`).

## Test plan
- [x] Run from worktree: `bash scripts/vm-shape.sh tibber | head` — produced 26 rows with current timestamps and label cardinality.
- [x] Empty-match case: `bash scripts/vm-shape.sh zzz_no_such_metric` — prints only the table header, exit 0.
- [ ] Reviewer: run `bash scripts/vm-shape.sh` (no filter) from the main checkout — confirm the table covers all metrics and stderr progress goes from `1/N` to `N/N`.
- [ ] Reviewer: temporarily rename `fetcher-core/python/.env.local` → confirm the script exits non-zero with a clear error.