### PR TITLE
feat(pool-pump-planner): backfill subcommand + run tag

### DIFF
--- a/docs/superpowers/plans/2026-04-21-pool-planner-backfill.md
+++ b/docs/superpowers/plans/2026-04-21-pool-planner-backfill.md
@@ -1,0 +1,1111 @@
+# Pool-pump planner — backfill subcommand — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `backfill` subcommand to `pool-pump-planner` that replays the planner for each of the last N days (default 30), anchored at each day's `POOL_PLAN_TIME`, writes tagged points to VM, and prints a stdout summary table.
+
+**Architecture:** Small internal refactor to let `plan()` run at an arbitrary "now", plus a new `backfill.go` that owns the day loop and printer. Live runs gain a `run=live` tag; backfill runs carry `run=backfill` + `anchor_date=YYYY-MM-DD`. Historical solar comes from the real PV metric (`sigenergy_pv_power_power_kw{string="total"}`) aggregated per slot. The existing Grafana plan panel adds `{run="live"}` so backfill writes don't pollute it.
+
+**Tech Stack:** Go 1.26, VictoriaMetrics/Prometheus API, InfluxDB v2 line protocol, Grafana SDK (TypeScript) for dashboard.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-pool-planner-backfill-design.md`
+
+---
+
+## File Structure
+
+Each file has one clear responsibility:
+
+| File | Responsibility | Change type |
+|------|---------------|-------------|
+| `pool-pump-planner/main.go` | Verb dispatch + scheduler loop | modify (tiny) |
+| `pool-pump-planner/planner.go` | One-shot plan: fetch → solve → write | modify (signature + tag threading) |
+| `pool-pump-planner/config.go` | Env-backed config struct | modify (add `Backfill bool`) |
+| `pool-pump-planner/vm.go` | VictoriaMetrics PromQL client | modify (add `fetchWaterTempAt`, `fetchSolarHistoricalKWh`) |
+| `pool-pump-planner/solar.go` | Solar kWh per slot — live forecast path | unchanged (rename nothing) |
+| `pool-pump-planner/backfill.go` | Day loop + stdout table | **new** |
+| `pool-pump-planner/backfill_test.go` | Unit tests for date math + formatter | **new** |
+| `grafana/src/panels/pool.ts` | Grafana pool panel definition | modify (add `{run="live"}` to plan panel) |
+
+---
+
+## Task 1: Refactor `plan()` to accept `now` and `extraTags`; tag live runs
+
+Foundation for everything else. Keeps existing behavior bit-for-bit when `extraTags` is `{"run":"live"}`.
+
+**Files:**
+- Modify: `pool-pump-planner/planner.go`
+- Modify: `pool-pump-planner/main.go`
+
+- [ ] **Step 1: Update `plan()` signature and body in `planner.go`**
+
+Replace the current `plan` function (lines 28–64) with:
+
+```go
+func plan(cfg *Config, now time.Time, extraTags map[string]string) error {
+	slotMinutes := cfg.SlotMinutes
+	horizonSlots := cfg.HorizonSlots()
+
+	now = now.UTC().Truncate(time.Hour)
+	slots := make([]time.Time, horizonSlots)
+	for i := 0; i < horizonSlots; i++ {
+		slots[i] = now.Add(time.Duration(i*slotMinutes) * time.Minute)
+	}
+
+	prices := cfg.fetchHourlyPrices(slots)
+	var solar []float64
+	if cfg.Backfill {
+		solar = cfg.fetchSolarHistoricalKWh(slots)
+	} else {
+		solar = cfg.fetchSolarForecast(slots)
+	}
+	waterTemp, waterOK := cfg.fetchWaterTempAt(now)
+
+	missing := missingInputs(prices, waterOK, horizonSlots)
+	if missing != "" {
+		log.Printf("[planner] missing inputs %s, falling back to static schedule", missing)
+		sch := fallbackSchedule(cfg, slots)
+		stats := fallbackStats(cfg, sch, prices, solar)
+		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags)
+	}
+
+	targetHours := computeTargetHours(cfg, waterTemp, waterOK)
+	log.Printf("[planner] horizon=24h target_hours=%d water_temp=%.2f min=%d max=%d",
+		targetHours, waterTemp, cfg.MinHours, cfg.MaxHours)
+
+	sch, stats, err := solve(cfg, slots, prices, solar, targetHours)
+	if err != nil {
+		log.Printf("[planner] MILP failed: %v, falling back", err)
+		sch = fallbackSchedule(cfg, slots)
+		stats = fallbackStats(cfg, sch, prices, solar)
+		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags)
+	}
+	return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags)
+}
+```
+
+- [ ] **Step 2: Update `writePlan()` signature to accept extraTags**
+
+In `planner.go`, change `writePlan` to:
+
+```go
+func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) error {
+	applyTags := func(p *Point) *Point {
+		for k, v := range extraTags {
+			p.Tag(k, v)
+		}
+		return p
+	}
+
+	points := make([]*Point, 0, len(slots)+1)
+	for t, slot := range slots {
+		p := applyTags(NewPoint("pool_iqpump_plan").
+			Tag("horizon", "24h").
+			Tag("mode", mode)).
+			Field("on", sch[t]).
+			Field("cost_sek", stats.costPerSlot[t]).
+			At(slot)
+		priceField := 0.0
+		if len(prices) > t && !math.IsNaN(prices[t]) {
+			priceField = prices[t]
+		}
+		p.Field("price_sek_per_kwh", priceField)
+		solarField := 0.0
+		if len(solar) > t {
+			solarField = solar[t]
+		}
+		p.Field("solar_kwh", solarField)
+		points = append(points, p)
+	}
+
+	waterC := 0.0
+	if waterOK {
+		waterC = waterTemp
+	}
+
+	missingTag := missing
+	if missingTag == "" {
+		missingTag = "none"
+	}
+
+	summary := applyTags(NewPoint("pool_iqpump_plan_summary").
+		Tag("horizon", "24h").
+		Tag("mode", mode).
+		Tag("missing_inputs", missingTag)).
+		Field("planned_hours", stats.plannedHours).
+		Field("target_hours", targetHours).
+		Field("slot_minutes", cfg.SlotMinutes).
+		Field("expected_cost_sek", stats.expectedCostSEK).
+		Field("slack_hours", stats.slackHours).
+		Field("water_temp_c", waterC).
+		At(slots[0])
+	points = append(points, summary)
+
+	if err := cfg.WritePoints(points); err != nil {
+		return err
+	}
+	log.Printf("[planner] plan written (mode=%s, slot=%dm): %.2f/%d hours, cost=%.2f SEK (slack=%.2f missing=%s)",
+		mode, cfg.SlotMinutes, stats.plannedHours, targetHours, stats.expectedCostSEK, stats.slackHours, missingTag)
+	return nil
+}
+```
+
+- [ ] **Step 3: Update `runPlanner()` in `planner.go`**
+
+Replace with:
+
+```go
+func runPlanner(cfg *Config) {
+	if err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
+		log.Printf("[planner] run failed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 4: Run build + existing tests**
+
+```bash
+cd pool-pump-planner && go build ./... && go test ./...
+```
+
+Expected: all existing tests pass (PASS), no compile errors. If `fetchWaterTempAt` and `fetchSolarHistoricalKWh` don't exist yet, this step will fail. In that case, temporarily stub them in the affected file so the refactor compiles:
+
+```go
+// pool-pump-planner/vm.go, append at bottom (temporary until Task 2)
+func (c *Config) fetchWaterTempAt(_ time.Time) (float64, bool) { return c.fetchWaterTemp() }
+
+// pool-pump-planner/solar.go, append at bottom (temporary until Task 3)
+func (c *Config) fetchSolarHistoricalKWh(slots []time.Time) []float64 { return make([]float64, len(slots)) }
+```
+
+Re-run `go build ./... && go test ./...`. Expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pool-pump-planner/planner.go pool-pump-planner/vm.go pool-pump-planner/solar.go
+git commit -m "refactor(pool-pump-planner): plan() takes now and extraTags" \
+  -m "Preparation for the backfill subcommand. Live runs now emit a run=live tag on every plan point. No behavior change beyond the tag."
+```
+
+---
+
+## Task 2: Replace the `fetchWaterTempAt` stub with a real point-in-time query
+
+**Files:**
+- Modify: `pool-pump-planner/vm.go`
+
+- [ ] **Step 1: Replace the stub and add a helper method for point-in-time instant queries**
+
+In `vm.go`, replace the temporary `fetchWaterTempAt` stub with:
+
+```go
+func (c *Config) queryPromInstantAt(promql string, at time.Time, lookbackDelta string) ([]promResult, error) {
+	base := c.vmBaseURL()
+	if base == "" {
+		return nil, fmt.Errorf("VictoriaMetrics query URL not configured")
+	}
+	q := url.Values{}
+	q.Set("query", promql)
+	if !at.IsZero() {
+		q.Set("time", strconv.FormatInt(at.Unix(), 10))
+	}
+	if lookbackDelta != "" {
+		q.Set("lookback_delta", lookbackDelta)
+	}
+	return c.promGet(base+"/api/v1/query?"+q.Encode(), false)
+}
+
+func (c *Config) fetchWaterTempAt(at time.Time) (float64, bool) {
+	result, err := c.queryPromInstantAt("pool_temperature_value", at, "")
+	if err != nil {
+		log.Printf("[planner] water temp query failed: %v", err)
+		return 0, false
+	}
+	if len(result) == 0 || len(result[0].Values) == 0 {
+		return 0, false
+	}
+	return result[0].Values[0].Value, true
+}
+```
+
+Also change the existing `fetchWaterTemp` (lines 201–211) to a one-liner wrapper:
+
+```go
+func (c *Config) fetchWaterTemp() (float64, bool) {
+	return c.fetchWaterTempAt(time.Time{})
+}
+```
+
+`time.Time{}` (zero value) tells `queryPromInstantAt` to skip the `time` param, matching original behavior.
+
+- [ ] **Step 2: Build + test**
+
+```bash
+cd pool-pump-planner && go build ./... && go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pool-pump-planner/vm.go
+git commit -m "feat(pool-pump-planner): add fetchWaterTempAt for historical queries"
+```
+
+---
+
+## Task 3: Replace the `fetchSolarHistoricalKWh` stub with a real VM query
+
+**Files:**
+- Modify: `pool-pump-planner/solar.go`
+
+- [ ] **Step 1: Write a failing unit test for slot-to-hour kWh conversion**
+
+Append to the `solar.go` file location's test — create `pool-pump-planner/solar_test.go` if it doesn't exist:
+
+```go
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSamplesToKWhPerSlot(t *testing.T) {
+	// 4 slots of 15 minutes, starting at a round epoch.
+	start := time.Unix(1700000000, 0).UTC()
+	slotMinutes := 15
+	slots := []time.Time{
+		start,
+		start.Add(15 * time.Minute),
+		start.Add(30 * time.Minute),
+		start.Add(45 * time.Minute),
+	}
+	// Samples: slot 0 avg = 2 kW, slot 1 avg = 0.5 kW, slot 2 = no samples, slot 3 = 1 kW.
+	samples := []promSample{
+		{Timestamp: float64(start.Unix()), Value: 2.0},
+		{Timestamp: float64(start.Add(15 * time.Minute).Unix()), Value: 0.5},
+		// slot 2 skipped
+		{Timestamp: float64(start.Add(45 * time.Minute).Unix()), Value: 1.0},
+	}
+	got := samplesToKWhPerSlot(samples, slots, slotMinutes)
+	want := []float64{
+		2.0 * 0.25, // 0.5 kWh
+		0.5 * 0.25, // 0.125
+		0,          // no data
+		1.0 * 0.25, // 0.25
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Errorf("slot %d: got %.4f want %.4f", i, got[i], want[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+cd pool-pump-planner && go test -run TestSamplesToKWhPerSlot ./...
+```
+
+Expected: FAIL (`samplesToKWhPerSlot undefined`).
+
+- [ ] **Step 3: Replace the stub with real implementation**
+
+In `solar.go`, replace the temporary `fetchSolarHistoricalKWh` stub with:
+
+```go
+// fetchSolarHistoricalKWh returns PV production (kWh) per slot, derived from the
+// inverter's historical power metric. Used in backfill mode where forecast.solar
+// has no historical endpoint.
+func (c *Config) fetchSolarHistoricalKWh(slots []time.Time) []float64 {
+	out := make([]float64, len(slots))
+	if len(slots) == 0 {
+		return out
+	}
+	slotSeconds := (slots[1].Unix() - slots[0].Unix())
+	if slotSeconds <= 0 {
+		slotSeconds = 900
+	}
+	slotRange := fmt.Sprintf("%ds", slotSeconds)
+	promql := `avg_over_time(sigenergy_pv_power_power_kw{string="total"}[` + slotRange + `])`
+	start := slots[0]
+	end := slots[len(slots)-1]
+	result, err := c.queryPromRange(promql, start, end, int(slotSeconds))
+	if err != nil {
+		log.Printf("[planner] historical solar query failed: %v", err)
+		return out
+	}
+	if len(result) == 0 {
+		return out
+	}
+	slotMinutes := int(slotSeconds / 60)
+	return samplesToKWhPerSlot(result[0].Values, slots, slotMinutes)
+}
+
+// samplesToKWhPerSlot buckets kW samples onto slot start-times and converts to
+// kWh assuming each sample represents the avg kW over one slot.
+func samplesToKWhPerSlot(samples []promSample, slots []time.Time, slotMinutes int) []float64 {
+	out := make([]float64, len(slots))
+	slotHours := float64(slotMinutes) / 60.0
+	byTs := make(map[int64]float64, len(samples))
+	for _, s := range samples {
+		ts := int64(s.Timestamp)
+		byTs[ts] = s.Value
+	}
+	for i, slot := range slots {
+		if v, ok := byTs[slot.Unix()]; ok {
+			out[i] = v * slotHours
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+cd pool-pump-planner && go test -run TestSamplesToKWhPerSlot ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pool-pump-planner/solar.go pool-pump-planner/solar_test.go
+git commit -m "feat(pool-pump-planner): add fetchSolarHistoricalKWh via PV metric"
+```
+
+---
+
+## Task 4: Add `Backfill` flag to Config
+
+**Files:**
+- Modify: `pool-pump-planner/config.go`
+
+- [ ] **Step 1: Add `Backfill bool` field to the `Config` struct**
+
+In `config.go`, add after the `PlanTime string` field (line ~49):
+
+```go
+	// Backfill selects the historical data fetchers (historical solar via VM
+	// instead of forecast.solar). Set only by the backfill subcommand.
+	Backfill bool
+```
+
+- [ ] **Step 2: Build + tests**
+
+```bash
+cd pool-pump-planner && go build ./... && go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pool-pump-planner/config.go
+git commit -m "feat(pool-pump-planner): add Backfill config flag"
+```
+
+---
+
+## Task 5: Create `backfill.go` — types and date iterator
+
+**Files:**
+- Create: `pool-pump-planner/backfill.go`
+- Create: `pool-pump-planner/backfill_test.go`
+
+- [ ] **Step 1: Write failing test for date iteration**
+
+Create `pool-pump-planner/backfill_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackfillDates(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	got := backfillDates(end, 3, tz)
+	want := []time.Time{
+		time.Date(2026, 4, 18, 0, 0, 0, 0, tz),
+		time.Date(2026, 4, 19, 0, 0, 0, 0, tz),
+		time.Date(2026, 4, 20, 0, 0, 0, 0, tz),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("[%d] got=%s want=%s", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBackfillDatesZeroDays(t *testing.T) {
+	tz := time.UTC
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	got := backfillDates(end, 0, tz)
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+cd pool-pump-planner && go test -run TestBackfillDates ./...
+```
+
+Expected: FAIL (`backfillDates undefined`).
+
+- [ ] **Step 3: Create `backfill.go` with types and the date iterator**
+
+Create `pool-pump-planner/backfill.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// backfillResult is one row in the stdout summary table.
+type backfillResult struct {
+	Date        time.Time // site-local midnight of the anchor day
+	Mode        string    // "optimal" / "fallback" / "ERR"
+	Hours       float64
+	TargetHours int
+	CostSEK     float64
+	SlackHours  float64
+	Missing     string // "none" if everything was present
+	OnHours     []int  // unique local clock hours where any slot was on
+	Err         error  // non-nil for a day that completely failed
+}
+
+// backfillDates returns `days` calendar-day midnights in the given tz, oldest
+// first, ending on `end` (inclusive). `end` is truncated to the day in tz.
+func backfillDates(end time.Time, days int, tz *time.Location) []time.Time {
+	if days <= 0 {
+		return nil
+	}
+	end = end.In(tz)
+	endDay := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, tz)
+	out := make([]time.Time, 0, days)
+	for i := days - 1; i >= 0; i-- {
+		out = append(out, endDay.AddDate(0, 0, -i))
+	}
+	return out
+}
+
+// formatBackfillTable renders the result slice as a stdout-ready table,
+// newest first.
+func formatBackfillTable(results []backfillResult, end time.Time, tz *time.Location, planTime string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Pool pump backfill — %d days ending %s (anchor %s %s)\n\n",
+		len(results), end.In(tz).Format("2006-01-02"), planTime, tz.String())
+	fmt.Fprintf(&b, "  %-10s  %-9s  %5s  %3s  %10s  %5s  %-12s  ON_HOURS (local)\n",
+		"DATE", "MODE", "HRS", "TGT", "COST(SEK)", "SLACK", "MISSING")
+
+	// iterate newest first
+	sorted := make([]backfillResult, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date.After(sorted[j].Date) })
+
+	totHours := 0.0
+	totTgt := 0
+	totCost := 0.0
+	failures := 0
+	for _, r := range sorted {
+		date := r.Date.Format("2006-01-02")
+		if r.Err != nil {
+			fmt.Fprintf(&b, "  %-10s  %-9s  %s\n", date, "ERR", r.Err.Error())
+			failures++
+			continue
+		}
+		on := make([]string, 0, len(r.OnHours))
+		for _, h := range r.OnHours {
+			on = append(on, fmt.Sprintf("%02d", h))
+		}
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f  %5.1f  %-12s  %s\n",
+			date, r.Mode, r.Hours, r.TargetHours, r.CostSEK, r.SlackHours,
+			ifEmpty(r.Missing, "-"), strings.Join(on, " "))
+		totHours += r.Hours
+		totTgt += r.TargetHours
+		totCost += r.CostSEK
+	}
+	fmt.Fprintf(&b, "  %s\n", strings.Repeat("─", 90))
+	succ := len(results) - failures
+	if succ > 0 {
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f   avg/day %.2fh, %.2f SEK\n",
+			"Totals", "", totHours, totTgt, totCost, totHours/float64(succ), totCost/float64(succ))
+	}
+	fmt.Fprintf(&b, "  Failures: %d\n", failures)
+	return b.String()
+}
+
+func ifEmpty(s, def string) string {
+	if s == "" || s == "none" {
+		return def
+	}
+	return s
+}
+
+// onHoursFromSchedule returns the sorted unique local clock hours in which at
+// least one slot is 1.
+func onHoursFromSchedule(sch []int, slots []time.Time, tz *time.Location) []int {
+	seen := map[int]bool{}
+	for i, v := range sch {
+		if v == 1 {
+			seen[slots[i].In(tz).Hour()] = true
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for h := range seen {
+		out = append(out, h)
+	}
+	sort.Ints(out)
+	return out
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+cd pool-pump-planner && go test -run TestBackfillDates ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pool-pump-planner/backfill.go pool-pump-planner/backfill_test.go
+git commit -m "feat(pool-pump-planner): add backfill types and date iterator"
+```
+
+---
+
+## Task 6: Implement `runBackfill` and stdout table
+
+**Files:**
+- Modify: `pool-pump-planner/backfill.go`
+- Modify: `pool-pump-planner/backfill_test.go`
+- Modify: `pool-pump-planner/planner.go` (expose the per-slot schedule/stats through plan())
+
+Current `plan()` writes directly to VM and returns only `error`. We need to also hand the per-day schedule/stats back to `runBackfill` for the table. Smallest change: let `plan()` return a `planReport` struct (fields empty on error) in addition to error; callers that don't care about the return (runPlanner) ignore it.
+
+- [ ] **Step 1: Introduce `planReport` in `planner.go`**
+
+At the top of `planner.go` (below `planStats`), add:
+
+```go
+// planReport is the outcome of one plan() invocation, used by the backfill
+// table. Empty/zero fields on error.
+type planReport struct {
+	Mode        string
+	Hours       float64
+	TargetHours int
+	CostSEK     float64
+	SlackHours  float64
+	Missing     string // "none" when nothing missing
+	OnHours     []int  // unique local clock hours where any slot was on
+}
+```
+
+Change `plan()` signature to return `(planReport, error)`. Update the three `writePlan(...)` call sites inside `plan()` to:
+
+```go
+// fallback path (missing inputs)
+if err := writePlan(...); err != nil { return planReport{}, err }
+return planReport{
+	Mode:        "fallback",
+	Hours:       stats.plannedHours,
+	TargetHours: tgt,
+	CostSEK:     stats.expectedCostSEK,
+	SlackHours:  stats.slackHours,
+	Missing:     missing,
+	OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
+}, nil
+```
+
+And analogous returns for the MILP-infeasible fallback and the optimal path (`Mode: "optimal"`, `Missing: "none"`). Ensure the `runPlanner` wrapper ignores the report:
+
+```go
+func runPlanner(cfg *Config) {
+	if _, err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
+		log.Printf("[planner] run failed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Write failing table-formatter test**
+
+Append to `pool-pump-planner/backfill_test.go`:
+
+```go
+func TestFormatBackfillTable(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	results := []backfillResult{
+		{
+			Date: time.Date(2026, 4, 19, 0, 0, 0, 0, tz),
+			Mode: "optimal", Hours: 6.0, TargetHours: 6, CostSEK: 9.81, SlackHours: 0.0,
+			Missing: "none", OnHours: []int{1, 2, 3, 4, 13, 14},
+		},
+		{
+			Date: time.Date(2026, 4, 20, 0, 0, 0, 0, tz),
+			Mode: "fallback", Hours: 8.0, TargetHours: 8, CostSEK: 18.40, SlackHours: 0.0,
+			Missing: "prices", OnHours: []int{1, 2, 3, 4, 12, 13, 14, 15},
+		},
+	}
+	out := formatBackfillTable(results, end, tz, "14:05")
+	if !strings.Contains(out, "2026-04-20") {
+		t.Errorf("expected 2026-04-20 row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "prices") {
+		t.Errorf("expected prices in missing col, got:\n%s", out)
+	}
+	// newest first: 04-20 should appear before 04-19
+	pos20 := strings.Index(out, "2026-04-20")
+	pos19 := strings.Index(out, "2026-04-19")
+	if pos19 < pos20 || pos20 < 0 {
+		t.Errorf("expected 04-20 before 04-19 (newest first); positions 04-20=%d 04-19=%d\n%s", pos20, pos19, out)
+	}
+	if !strings.Contains(out, "Failures: 0") {
+		t.Errorf("expected Failures: 0, got:\n%s", out)
+	}
+}
+```
+
+Add `"strings"` to the test file's imports.
+
+- [ ] **Step 3: Run test, verify pass**
+
+```bash
+cd pool-pump-planner && go test -run TestFormatBackfillTable ./...
+```
+
+Expected: PASS (`formatBackfillTable` was already implemented in Task 5).
+
+- [ ] **Step 4: Implement `runBackfill` in `backfill.go`**
+
+Append to `backfill.go`:
+
+```go
+func runBackfill(cfg *Config, days int, end time.Time, dryRun bool) error {
+	if days <= 0 {
+		return fmt.Errorf("--days must be >= 1, got %d", days)
+	}
+	cfg.Backfill = true
+
+	planHH, planMM, err := parseHHMM(cfg.PlanTime)
+	if err != nil {
+		return fmt.Errorf("POOL_PLAN_TIME parse: %w", err)
+	}
+
+	dates := backfillDates(end, days, cfg.Timezone)
+	results := make([]backfillResult, 0, len(dates))
+
+	for _, d := range dates {
+		anchorLocal := time.Date(d.Year(), d.Month(), d.Day(), planHH, planMM, 0, 0, cfg.Timezone)
+		tags := map[string]string{
+			"run":         "backfill",
+			"anchor_date": d.Format("2006-01-02"),
+		}
+
+		origHost, origToken := "", ""
+		if dryRun {
+			// Temporarily blank out credentials so WritePoints no-ops (it checks
+			// both and logs-and-returns). Cheaper than threading a flag through.
+			origHost, origToken = cfg.InfluxHost, cfg.InfluxToken
+			cfg.InfluxHost, cfg.InfluxToken = "", ""
+		}
+		report, planErr := plan(cfg, anchorLocal.UTC(), tags)
+		if dryRun {
+			cfg.InfluxHost, cfg.InfluxToken = origHost, origToken
+		}
+
+		if planErr != nil {
+			results = append(results, backfillResult{Date: d, Mode: "ERR", Err: planErr})
+			continue
+		}
+		results = append(results, backfillResult{
+			Date:        d,
+			Mode:        report.Mode,
+			Hours:       report.Hours,
+			TargetHours: report.TargetHours,
+			CostSEK:     report.CostSEK,
+			SlackHours:  report.SlackHours,
+			Missing:     report.Missing,
+			OnHours:     report.OnHours,
+		})
+	}
+
+	fmt.Print(formatBackfillTable(results, end, cfg.Timezone, cfg.PlanTime))
+
+	anyOK := false
+	for _, r := range results {
+		if r.Err == nil {
+			anyOK = true
+			break
+		}
+	}
+	if !anyOK {
+		return fmt.Errorf("all %d backfill days failed", len(results))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Build + run all tests**
+
+```bash
+cd pool-pump-planner && go build ./... && go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pool-pump-planner/planner.go pool-pump-planner/backfill.go pool-pump-planner/backfill_test.go
+git commit -m "feat(pool-pump-planner): implement runBackfill and table formatter"
+```
+
+---
+
+## Task 7: Wire the `backfill` subcommand in `main.go`
+
+**Files:**
+- Modify: `pool-pump-planner/main.go`
+
+- [ ] **Step 1: Replace `main.go` with the subcommand dispatcher**
+
+Replace the entire `main.go` body with:
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	if len(os.Args) >= 2 && os.Args[1] == "backfill" {
+		cfg := loadConfig()
+		if err := backfillCLI(cfg, os.Args[2:]); err != nil {
+			log.Fatalf("backfill: %v", err)
+		}
+		return
+	}
+
+	once := flag.Bool("once", false, "run planner once and exit")
+	flag.Parse()
+
+	cfg := loadConfig()
+
+	if *once || (len(os.Args) > 1 && os.Args[1] == "once") {
+		runPlanner(cfg)
+		return
+	}
+
+	// Run once on startup (mirroring python schedule.run_all), then daily at POOL_PLAN_TIME.
+	runPlanner(cfg)
+
+	hh, mm, err := parseHHMM(cfg.PlanTime)
+	if err != nil {
+		log.Fatalf("invalid POOL_PLAN_TIME %q: %v", cfg.PlanTime, err)
+	}
+
+	for {
+		next := nextDailyRun(time.Now().In(cfg.Timezone), hh, mm)
+		delay := time.Until(next)
+		log.Printf("[planner] next run at %s (%.0fs)", next.Format(time.RFC3339), delay.Seconds())
+		time.Sleep(delay)
+		runPlanner(cfg)
+	}
+}
+
+// backfillCLI parses subcommand flags and dispatches to runBackfill.
+func backfillCLI(cfg *Config, args []string) error {
+	fs := flag.NewFlagSet("backfill", flag.ExitOnError)
+	days := fs.Int("days", 30, "number of calendar days to backfill")
+	endFlag := fs.String("end", "", "last day to plan (YYYY-MM-DD, site-local) — default: yesterday")
+	dryRun := fs.Bool("dry-run", false, "compute + print the table, skip VM writes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var end time.Time
+	if *endFlag == "" {
+		now := time.Now().In(cfg.Timezone)
+		end = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, cfg.Timezone).AddDate(0, 0, -1)
+	} else {
+		d, err := time.ParseInLocation("2006-01-02", *endFlag, cfg.Timezone)
+		if err != nil {
+			return fmt.Errorf("--end %q: %w", *endFlag, err)
+		}
+		end = d
+	}
+
+	return runBackfill(cfg, *days, end, *dryRun)
+}
+
+func parseHHMM(s string) (int, int, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected HH:MM, got %q", s)
+	}
+	hh, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid hour %q: %w", parts[0], err)
+	}
+	mm, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minute %q: %w", parts[1], err)
+	}
+	if hh < 0 || hh > 23 || mm < 0 || mm > 59 {
+		return 0, 0, fmt.Errorf("out of range HH:MM in %q", s)
+	}
+	return hh, mm, nil
+}
+
+func nextDailyRun(now time.Time, hh, mm int) time.Time {
+	candidate := time.Date(now.Year(), now.Month(), now.Day(), hh, mm, 0, 0, now.Location())
+	if !candidate.After(now) {
+		candidate = candidate.AddDate(0, 0, 1)
+	}
+	return candidate
+}
+```
+
+- [ ] **Step 2: Build + test**
+
+```bash
+cd pool-pump-planner && go build ./... && go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Smoke-test the CLI shape with `--help`-style invocation**
+
+```bash
+cd pool-pump-planner && go run . backfill --help 2>&1 || true
+```
+
+Expected: usage output lists `-days`, `-end`, `-dry-run`. (`--help` may exit with status 2 for unknown flag — OK, we're just confirming flags are registered.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pool-pump-planner/main.go
+git commit -m "feat(pool-pump-planner): add backfill subcommand dispatcher"
+```
+
+---
+
+## Task 8: Update the Grafana pool-plan panel to filter `run="live"`
+
+**Files:**
+- Modify: `grafana/src/panels/pool.ts`
+- Modify: `grafana/dist/...` (regenerated JSON — whatever `npm run build` emits)
+
+- [ ] **Step 1: Add `{run="live"}` to the three plan-panel queries**
+
+In `grafana/src/panels/pool.ts`, change lines 105–107 from:
+
+```ts
+.withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on[$__interval])', 'on'))
+.withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh[$__interval])', 'price_sek_per_kwh'))
+.withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh[$__interval])', 'solar_kwh'))
+```
+
+To:
+
+```ts
+.withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run="live"}[$__interval])', 'on'))
+.withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval])', 'price_sek_per_kwh'))
+.withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval])', 'solar_kwh'))
+```
+
+- [ ] **Step 2: Regenerate the dashboard JSON via `npm run build`**
+
+```bash
+cd grafana && npm install --no-audit --no-fund 2>&1 | tail -5 && GRAFANA_SKIP_UPLOAD=1 npm run build
+```
+
+Expected: exits 0, produces updated JSON under whatever path the build script writes to (check `git status` after).
+
+- [ ] **Step 3: Verify git-diff only shows the three-query change**
+
+```bash
+git status --short grafana/
+git diff grafana/
+```
+
+Expected: changes in `grafana/src/panels/pool.ts` and the generated JSON file. If the diff is larger (unrelated panels churned), open the diff and confirm the extra changes are harmless re-ordering.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add grafana/src/panels/pool.ts grafana/
+git commit -m "feat(grafana): filter pool-plan panel to run=live"
+```
+
+---
+
+## Task 9: End-to-end verification against live VM
+
+**Files:** none (manual checks).
+
+- [ ] **Step 1: Dry-run 3 days against live VM**
+
+Ensure `INFLUX_HOST`, `INFLUX_TOKEN` etc. are set (they are via the shell or `.env.local`):
+
+```bash
+cd pool-pump-planner
+set -a && source ../fetcher-core/python/.env.local && set +a
+go run . backfill --days=3 --dry-run 2>&1 | tee /tmp/iot_fetcher/backfill-dry.log
+```
+
+Expected: 3-row stdout table printed, latest 3 days (ending yesterday). Each row shows a mode + hours + cost. `Failures: 0`. Log lines from the planner appear above the table. No VM writes (confirmed because `INFLUX_HOST` was temporarily cleared inside the loop).
+
+If any row shows `ERR`, inspect the log and fix before proceeding.
+
+- [ ] **Step 2: Real run of 3 days**
+
+```bash
+cd pool-pump-planner
+go run . backfill --days=3 2>&1 | tee /tmp/iot_fetcher/backfill-real.log
+```
+
+Expected: same stdout table. This time `[influx] wrote N points` lines appear.
+
+- [ ] **Step 3: Verify VM received the tagged points**
+
+```bash
+set -a && source fetcher-core/python/.env.local && set +a
+curl -s "$INFLUX_HOST/api/v1/query?query=count_over_time(pool_iqpump_plan_on%7Brun%3D%22backfill%22%7D%5B30d%5D)" \
+  -H "Authorization: Bearer $INFLUX_TOKEN"
+```
+
+Expected: `status=success`, a non-zero count (≈ 3 days × 96 slots = ~288).
+
+- [ ] **Step 4: Run the full 30-day backfill**
+
+```bash
+cd pool-pump-planner && go run . backfill 2>&1 | tee /tmp/iot_fetcher/backfill-30d.log
+```
+
+Expected: 30-row table. Glance at hours/cost for sanity. Document any oddities in the PR description.
+
+- [ ] **Step 5: (No commit for this task — verification only.)**
+
+---
+
+## Task 10: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /Users/filip/Desktop/own/iot_fetcher/.claude/worktrees/agent-a721076e
+git push -u origin HEAD
+```
+
+Expected: "Branch 'fix/pool-pump-planner-temperature-metric-typo' set up to track 'origin/...'" (note: branch name from the worktree; we're reusing it since the prior temp-typo commit is already in main under a different SHA). If the push is rejected for non-fast-forward because the remote branch still exists, push with `--force-with-lease` since no collaborators share this branch.
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --title "feat(pool-pump-planner): backfill subcommand + run tag" --body "$(cat <<'EOF'
+## Summary
+
+Adds `pool-pump-planner backfill` — a one-shot CLI that replays the planner for each of the last N days (default 30), anchored at each day's `POOL_PLAN_TIME`, writes VM points tagged `run=backfill`, and prints a stdout summary table.
+
+Live runs also now carry `run=live` on every plan point. The existing Grafana plan panel is filtered to `{run="live"}` so backfill writes don't pollute it.
+
+Historical solar comes from the real PV metric (`sigenergy_pv_power_power_kw{string="total"}`) aggregated per slot — forecast.solar has no real historical endpoint.
+
+## Design
+
+See `docs/superpowers/specs/2026-04-21-pool-planner-backfill-design.md` (committed in this branch).
+
+## Test plan
+
+Local (pre-merge):
+- [x] ``go test ./pool-pump-planner/...`` passes
+- [x] ``go run . backfill --dry-run --days=3`` prints a 3-row table, 0 VM writes
+- [x] ``go run . backfill --days=3`` writes tagged points; ``count_over_time(pool_iqpump_plan_on{run="backfill"}[7d])`` > 0
+- [x] ``go run . backfill`` 30-day run completes
+
+Post-merge:
+- [ ] Grafana dashboard deploys; the pool-plan panel shows only live data
+- [ ] Ad-hoc query on ``{run="backfill", anchor_date=...}`` returns each backfilled day
+
+## Follow-up (not in this PR)
+
+PV shadow mask for the live planner — the inverter curve shows morning shade until ~10h and a peak at 14h (vs solar noon ~13h). Mask env var noted in the spec.
+EOF
+)"
+```
+
+Return the PR URL printed by `gh pr create`.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- **CLI shape (days/end/dry-run):** Task 7 ✓
+- **Run tag on live + backfill:** Tasks 1 (live side) + 6 (backfill side via tags map) ✓
+- **`cfg.Backfill` bool:** Task 4 ✓
+- **`fetchWaterTempAt`:** Task 2 ✓
+- **`fetchSolarHistoricalKWh` via sigenergy metric:** Task 3 ✓
+- **`backfill.go` (types, orchestration, printer):** Tasks 5 + 6 ✓
+- **Stdout table, newest first, fallback/ERR rows:** Task 6 (implementation) + test in Task 6 ✓
+- **Per-day non-fatal errors, exit 1 if all fail:** Task 6 (`anyOK` guard) ✓
+- **`--dry-run` skips writes:** Task 6 (credential blanking) ✓
+- **Idempotency via (measurement, tags, ts):** implicit in line protocol — no test needed, spec says so ✓
+- **Grafana panel filtered to `run="live"`:** Task 8 ✓
+- **Dashboard regenerated via the TS build:** Task 8 ✓
+- **Non-goal: no forecast.solar history:** respected ✓
+- **Non-goal: no retro-writing `run=live` onto old points:** respected ✓
+- **Follow-up: PV shadow mask noted in PR body + spec:** Task 10 ✓
+
+No TBDs or "handle appropriately" placeholders. All code shown in full. Method and type names are consistent across tasks (`plan`, `planReport`, `runBackfill`, `backfillResult`, `backfillDates`, `formatBackfillTable`, `fetchSolarHistoricalKWh`, `fetchWaterTempAt`).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-pool-planner-backfill.md`.

--- a/docs/superpowers/specs/2026-04-21-pool-planner-backfill-design.md
+++ b/docs/superpowers/specs/2026-04-21-pool-planner-backfill-design.md
@@ -1,0 +1,174 @@
+# Pool-pump planner — backfill subcommand
+
+## Goal
+
+Let me re-run the planner for each of the last ~30 days as if it had fired at that day's `POOL_PLAN_TIME`, so I can see how the optimizer behaves across different real-world price, solar, and temperature profiles. Primary question it should answer: *"if we had been running this planner the last 30 days, what schedule would it have produced and what would it have cost?"*
+
+Scope is a one-shot local analysis tool, not a production feature.
+
+## CLI
+
+```
+pool-pump-planner                       # unchanged: one run + daily schedule at POOL_PLAN_TIME
+pool-pump-planner once                  # unchanged
+pool-pump-planner backfill [flags]      # NEW
+  --days=30                             # how many calendar days to plan (default 30)
+  --end=YYYY-MM-DD                      # last day (default: yesterday, site-local)
+  --dry-run                             # compute + print table, skip VM writes
+```
+
+Defaults produce "last 30 days ending yesterday, writing tagged points and printing a summary table". The existing `--once` flag keeps working for back-compat; `main.go` grows a small `os.Args[1]` verb dispatcher.
+
+## VM write strategy
+
+**New tag on every plan point, both live and backfill:**
+
+| Tag            | Value on live runs | Value on backfill runs  |
+|----------------|--------------------|-------------------------|
+| `run`          | `live`             | `backfill`              |
+| `anchor_date`  | (unset)            | `YYYY-MM-DD` (site-local)|
+| `mode`         | `optimal`/`fallback` (unchanged) | `optimal`/`fallback` (unchanged) |
+| `horizon`      | `24h` (unchanged)  | `24h` (unchanged)       |
+
+Tagging live runs with `run=live` is a small behavior change to existing writes, approved in design discussion. Re-running backfill is idempotent: `(measurement, tags, timestamp)` is identical, and VM/Influx line protocol overwrites.
+
+## Internal refactor
+
+### 1. `plan()` takes explicit `now` and a tag map
+
+```go
+func plan(cfg *Config, now time.Time, extraTags map[string]string) error
+```
+
+- Scheduled / `once` path: `plan(cfg, time.Now().UTC(), map[string]string{"run": "live"})`
+- Backfill: `plan(cfg, anchor, map[string]string{"run": "backfill", "anchor_date": date.Format("2006-01-02")})`
+
+`writePlan` merges `extraTags` into the `pool_iqpump_plan` and `pool_iqpump_plan_summary` points.
+
+### 2. Point-in-time-aware fetchers
+
+- `fetchHourlyPrices(slots)` — already parameterized on slots, no change.
+- `fetchWaterTempAt(t time.Time) (float64, bool)` — new VM instant query with `&time=<unix>`; existing `fetchWaterTemp()` becomes a one-line wrapper.
+- `fetchSolarKWh(slots) []float64` — dispatcher:
+  - `cfg.Backfill == false` → existing `fetchSolarForecast` (forecast.solar).
+  - `cfg.Backfill == true` → `fetchSolarHistoricalKWh(slots)`: VM range query `avg_over_time(sigenergy_pv_power_power_kw{string="total"}[<slot>])`, bucket samples by slot timestamp, convert `kW × slotHours` → kWh per slot.
+
+`cfg.Backfill` is set only by the backfill subcommand.
+
+### 3. New file `backfill.go`
+
+Contains:
+- `runBackfill(cfg *Config, days int, end time.Time, dryRun bool) error`
+- `backfillResult` struct with per-day fields (date, mode, hours, target, cost, slack, missing, onHours).
+- Day loop: for `i := 0..days-1`, compute `anchor = end.AddDate(0,0,-i) @ POOL_PLAN_TIME`, call `plan(cfg, anchor.UTC().Truncate(time.Hour), {"run":"backfill","anchor_date":...})`, collect the result.
+- Table printer.
+
+Keeps `planner.go` focused on "build, solve, write one plan".
+
+### 4. File layout diff
+
+```
+pool-pump-planner/
+  main.go         # verb dispatcher added
+  backfill.go     # NEW
+  planner.go      # plan() signature change, writePlan accepts tags
+  vm.go           # fetchWaterTempAt + historical PV query helper
+  solar.go        # fetchSolarKWh dispatcher
+  backfill_test.go # NEW
+```
+
+## Grafana dashboard update (in scope for same PR)
+
+File: `grafana/src/panels/pool.ts` — `pumpPlan` panel.
+
+Problem: current queries (e.g. `last_over_time(pool_iqpump_plan_on[$__interval])`) don't filter by `run`, so once backfill points start landing in VM they blend with live points in the "Poolpump plan" panel.
+
+Fix: add `{run="live"}` selector to each PromQL query in the `pumpPlan` panel so the existing visualization stays clean:
+
+```ts
+.withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run="live"}[$__interval])', 'on'))
+.withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval])', 'price_sek_per_kwh'))
+.withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval])', 'solar_kwh'))
+```
+
+Dashboard JSON regenerated via `convert_dashboard.py` per repo convention (CLAUDE.md).
+
+Backfill data is intentionally **not** given a panel in this PR — it's for ad-hoc analysis via Explore or direct PromQL queries. A dedicated backfill panel can be added later if useful.
+
+## Data flow (backfill path)
+
+```
+for each day in [end, end-1, ..., end-(days-1)]:
+    anchor_local = day @ POOL_PLAN_TIME (site-local)
+    now          = anchor_local.UTC().Truncate(time.Hour)
+    slots        = [now, now+slot, ..., now+24h)
+
+    prices       = VM range query over slots window
+    waterTemp    = VM instant query at anchor_local.UTC()
+    solar        = avg_over_time(sigenergy_pv_power_power_kw{string="total"}[slot]) per slot
+
+    → plan() runs MILP or fallback same as live
+    → writePlan() emits tagged points to VM (unless --dry-run)
+    → collect result for table
+```
+
+## Stdout table
+
+Printed after the loop finishes, newest first:
+
+```
+Pool pump backfill — 30 days ending 2026-04-20 (anchor 14:05 Europe/Stockholm)
+
+  DATE        MODE        HRS   TGT  COST(SEK)  SLACK  MISSING   ON_HOURS (local)
+  2026-04-20  optimal     6.0     6     11.42   0.0   -           00 01 02 03 13 14
+  2026-04-19  optimal     6.0     6      9.81   0.0   -           01 02 03 04 13 14
+  2026-04-18  fallback    8.0     8     18.40   0.0   prices      01 02 03 04 12 13 14 15
+  ...
+  2026-03-22  optimal     7.0     7     13.04   0.0   -           00 01 02 12 13 14 21
+  ──────────────────────────────────────────────────────────────────────────────────
+  Totals                 192.0   195    382.10   avg/day 6.40h, 12.74 SEK
+  Failures: 0             Days skipped for missing prices: 0
+```
+
+- `HRS/TGT` highlights when the solver hit slack.
+- `MISSING` surfaces whatever `writePlan`'s `missing_inputs` already tracks (`-` when `none`).
+- `ON_HOURS` is compact even for 15m slots: space-joined list of local clock hours in which any slot was `on`.
+- Failed days print with `ERR` in MODE and the error on the next indented line; loop continues.
+
+## Error handling
+
+- **Per-day failures are non-fatal.** Fetch errors, solver errors, or write errors: log, mark the row, move on. Matches the live path, which already logs-and-continues.
+- **Fatal:** bad flags (`--days=-1`, unparseable `--end`), config validation, VM auth failure on first call. Exit 1.
+- **Exit code on completion:** 0 if ≥1 day succeeded, 1 if *all* days failed.
+
+## Testing
+
+- `backfill_test.go` (new)
+  - Anchor-date math (`end=2026-04-20, days=3` → iterates `04-20, 04-19, 04-18`; DST boundary sanity).
+  - Table formatter: synthetic `[]backfillResult` → expected string (golden).
+  - `runBackfill` with a stub data provider (inject via a small interface inside the orchestration layer only; `cfg.Backfill bool` remains for the prod switch).
+- Existing `planner_test.go` / `milp_test.go` keep passing after the `plan()` signature change.
+- No integration test against real VM — too flaky for CI; the existing VM-fetcher tests cover that layer.
+
+## Follow-ups (out of scope)
+
+### PV shadow mask for live planner
+The `sigenergy_pv_power_power_kw` curve over the last week shows:
+- **06–09h local:** near-zero (0.01–0.23 kW) — the house shades the panels until mid-morning.
+- **10–12h:** ramp from 0.45 → 1.02 kW.
+- **13–14h:** peak (1.39–1.52 kW avg, 2.85–3.10 max).
+- **15–19h:** gradual descent.
+- **20–05h:** zero.
+
+forecast.solar predicts a symmetric bell centred near solar noon (~13:00 CEST); reality is shifted right and has a flat morning shoulder. This means the live planner over-weights the 8–11h window when choosing "cheap solar hours" for the pump.
+
+Proposed fix: `POOL_SOLAR_HOURLY_MASK` env var, 24 comma-separated multipliers in `[0,1]`, applied to `fetchSolarForecast`'s output by hour-of-day. Default = all 1s (no-op). Configurable per hour-of-day so the mask can be tuned against observed PV.
+
+### Backfill-dedicated Grafana panel
+If the stdout table isn't enough, add a panel that queries `{run="backfill"}` with `anchor_date` as a variable, to visualize any single backfilled day.
+
+## Non-goals
+
+- No historical solar forecast (forecast.solar has no real past-date API; their `history` endpoint is a calendar-day average and requires a paid plan).
+- No backfill scheduling / cron. One-shot CLI only.
+- No retro-write of `run=live` tag onto pre-existing live points in VM. New writes only.

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -102,10 +102,34 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('price_sek_per_kwh', 'Spotpris (SEK/kWh)', 'yellow'),
       overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
     ])
-    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run="live"}[$__interval])', 'on'))
-    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval])', 'price_sek_per_kwh'))
-    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval])', 'solar_kwh'))
+    // run!="backfill" matches both untagged legacy writes and the new run="live"
+    // tag — so the panel keeps working during the rpi5 redeploy window.
+    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval])', 'on'))
+    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval])', 'price_sek_per_kwh'))
+    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval])', 'solar_kwh'))
     .gridPos({ h: 8, w: 24, x: 0, y: 52 });
 
-  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan];
+  // Poolpump plan — 30-day backfill: per-day summary of planned hours + cost
+  // emitted by `pool-pump-planner backfill`. One summary point per anchor day,
+  // so step=1d gives one sample per day on the time axis.
+  const pumpPlanBackfill = new TimeseriesBuilder()
+    .title('Poolpump plan (30 dagar backfill)')
+    .datasource(VM_DS)
+    .colorScheme(paletteColor())
+    .thresholds(greenThreshold())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .insertNulls(SPAN_NULLS_MS)
+    .overrides([
+      overrideDisplayAndColor('planned_hours', 'Planerade timmar', 'blue'),
+      overrideDisplayAndColor('expected_cost_sek', 'Förväntad kostnad (SEK)', 'yellow'),
+      overrideDisplayAndColor('slack_hours', 'Slack (h)', 'orange'),
+    ])
+    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_summary_planned_hours{run="backfill"}[$__interval])', 'planned_hours'))
+    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_summary_expected_cost_sek{run="backfill"}[$__interval])', 'expected_cost_sek'))
+    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_summary_slack_hours{run="backfill"}[$__interval])', 'slack_hours'))
+    .timeFrom('now-30d')
+    .gridPos({ h: 8, w: 24, x: 0, y: 60 });
+
+  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan, pumpPlanBackfill];
 }

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -109,6 +109,11 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval]))', 'on'))
     .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval]))', 'price_sek_per_kwh'))
     .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval]))', 'solar_kwh'))
+    // Lock to a 48h window centred on now: timeFrom sets the window length and
+    // timeShift=-24h moves the window's end 24h into the future, so the panel
+    // always shows now-24h to now+24h regardless of the dashboard's global range.
+    .timeFrom('48h')
+    .timeShift('-24h')
     .gridPos({ h: 8, w: 12, x: 0, y: 52 });
 
   // Poolpump plan — 30-day backfill: per-day summary of planned hours + cost

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -102,9 +102,9 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('price_sek_per_kwh', 'Spotpris (SEK/kWh)', 'yellow'),
       overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
     ])
-    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on[$__interval])', 'on'))
-    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh[$__interval])', 'price_sek_per_kwh'))
-    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh[$__interval])', 'solar_kwh'))
+    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run="live"}[$__interval])', 'on'))
+    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval])', 'price_sek_per_kwh'))
+    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval])', 'solar_kwh'))
     .gridPos({ h: 8, w: 24, x: 0, y: 52 });
 
   return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan];

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -103,15 +103,18 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
     ])
     // run!="backfill" matches both untagged legacy writes and the new run="live"
-    // tag — so the panel keeps working during the rpi5 redeploy window.
-    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval])', 'on'))
-    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval])', 'price_sek_per_kwh'))
-    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval])', 'solar_kwh'))
-    .gridPos({ h: 8, w: 24, x: 0, y: 52 });
+    // tag. max() wrapper collapses multiple series that differ on mode/run
+    // (e.g. an optimal series from today and a fallback series from an older
+    // day) into one line on the plot.
+    .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval]))', 'on'))
+    .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval]))', 'price_sek_per_kwh'))
+    .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval]))', 'solar_kwh'))
+    .gridPos({ h: 8, w: 12, x: 0, y: 52 });
 
   // Poolpump plan — 30-day backfill: per-day summary of planned hours + cost
-  // emitted by `pool-pump-planner backfill`. One summary point per anchor day,
-  // so step=1d gives one sample per day on the time axis.
+  // emitted by `pool-pump-planner backfill`. Each anchor_date is its own VM
+  // series (different tag) with one point per day; sum without(anchor_date)
+  // collapses them so the panel draws a single line with 30 points.
   const pumpPlanBackfill = new TimeseriesBuilder()
     .title('Poolpump plan (30 dagar backfill)')
     .datasource(VM_DS)
@@ -125,11 +128,11 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('expected_cost_sek', 'Förväntad kostnad (SEK)', 'yellow'),
       overrideDisplayAndColor('slack_hours', 'Slack (h)', 'orange'),
     ])
-    .withTarget(vmExpr('A', 'last_over_time(pool_iqpump_plan_summary_planned_hours{run="backfill"}[$__interval])', 'planned_hours'))
-    .withTarget(vmExpr('B', 'last_over_time(pool_iqpump_plan_summary_expected_cost_sek{run="backfill"}[$__interval])', 'expected_cost_sek'))
-    .withTarget(vmExpr('C', 'last_over_time(pool_iqpump_plan_summary_slack_hours{run="backfill"}[$__interval])', 'slack_hours'))
+    .withTarget(vmExpr('A', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run="backfill"})', 'planned_hours'))
+    .withTarget(vmExpr('B', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="backfill"})', 'expected_cost_sek'))
+    .withTarget(vmExpr('C', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run="backfill"})', 'slack_hours'))
     .timeFrom('now-30d')
-    .gridPos({ h: 8, w: 24, x: 0, y: 60 });
+    .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 
   return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan, pumpPlanBackfill];
 }

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -109,11 +109,12 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval]))', 'on'))
     .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval]))', 'price_sek_per_kwh'))
     .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval]))', 'solar_kwh'))
-    // Lock to a 48h window centred on now: timeFrom sets the window length and
-    // timeShift=-24h moves the window's end 24h into the future, so the panel
-    // always shows now-24h to now+24h regardless of the dashboard's global range.
-    .timeFrom('48h')
-    .timeShift('-24h')
+    // Lock the panel to a fixed calendar-day window: today 00:00 -> 24:00.
+    // Grafana rejects negative timeShift, so a rolling now-24h..now+24h window
+    // isn't reachable at the panel level. This calendar-day form is the
+    // documented workaround and still exposes the fresh 24h forecast.
+    .timeFrom('now/d')
+    .timeShift('0d/d')
     .gridPos({ h: 8, w: 12, x: 0, y: 52 });
 
   // Poolpump plan — 30-day backfill: per-day summary of planned hours + cost

--- a/pool-pump-planner/backfill.go
+++ b/pool-pump-planner/backfill.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// backfillResult is one row in the stdout summary table.
+type backfillResult struct {
+	Date        time.Time // site-local midnight of the anchor day
+	Mode        string    // "optimal" / "fallback" / "ERR"
+	Hours       float64
+	TargetHours int
+	CostSEK     float64
+	SlackHours  float64
+	Missing     string // "none" if everything was present
+	OnHours     []int  // unique local clock hours where any slot was on
+	Err         error  // non-nil for a day that completely failed
+}
+
+// backfillDates returns `days` calendar-day midnights in the given tz, oldest
+// first, ending on `end` (inclusive). `end` is truncated to the day in tz.
+func backfillDates(end time.Time, days int, tz *time.Location) []time.Time {
+	if days <= 0 {
+		return nil
+	}
+	end = end.In(tz)
+	endDay := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, tz)
+	out := make([]time.Time, 0, days)
+	for i := days - 1; i >= 0; i-- {
+		out = append(out, endDay.AddDate(0, 0, -i))
+	}
+	return out
+}
+
+// formatBackfillTable renders the result slice as a stdout-ready table,
+// newest first.
+func formatBackfillTable(results []backfillResult, end time.Time, tz *time.Location, planTime string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Pool pump backfill — %d days ending %s (anchor %s %s)\n\n",
+		len(results), end.In(tz).Format("2006-01-02"), planTime, tz.String())
+	fmt.Fprintf(&b, "  %-10s  %-9s  %5s  %3s  %10s  %5s  %-12s  ON_HOURS (local)\n",
+		"DATE", "MODE", "HRS", "TGT", "COST(SEK)", "SLACK", "MISSING")
+
+	sorted := make([]backfillResult, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date.After(sorted[j].Date) })
+
+	totHours := 0.0
+	totTgt := 0
+	totCost := 0.0
+	failures := 0
+	for _, r := range sorted {
+		date := r.Date.Format("2006-01-02")
+		if r.Err != nil {
+			fmt.Fprintf(&b, "  %-10s  %-9s  %s\n", date, "ERR", r.Err.Error())
+			failures++
+			continue
+		}
+		on := make([]string, 0, len(r.OnHours))
+		for _, h := range r.OnHours {
+			on = append(on, fmt.Sprintf("%02d", h))
+		}
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f  %5.1f  %-12s  %s\n",
+			date, r.Mode, r.Hours, r.TargetHours, r.CostSEK, r.SlackHours,
+			ifEmpty(r.Missing, "-"), strings.Join(on, " "))
+		totHours += r.Hours
+		totTgt += r.TargetHours
+		totCost += r.CostSEK
+	}
+	fmt.Fprintf(&b, "  %s\n", strings.Repeat("─", 90))
+	succ := len(results) - failures
+	if succ > 0 {
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f   avg/day %.2fh, %.2f SEK\n",
+			"Totals", "", totHours, totTgt, totCost, totHours/float64(succ), totCost/float64(succ))
+	}
+	fmt.Fprintf(&b, "  Failures: %d\n", failures)
+	return b.String()
+}
+
+func ifEmpty(s, def string) string {
+	if s == "" || s == "none" {
+		return def
+	}
+	return s
+}
+
+// onHoursFromSchedule returns the sorted unique local clock hours in which at
+// least one slot is 1.
+func onHoursFromSchedule(sch []int, slots []time.Time, tz *time.Location) []int {
+	seen := map[int]bool{}
+	for i, v := range sch {
+		if v == 1 {
+			seen[slots[i].In(tz).Hour()] = true
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for h := range seen {
+		out = append(out, h)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/pool-pump-planner/backfill.go
+++ b/pool-pump-planner/backfill.go
@@ -103,3 +103,67 @@ func onHoursFromSchedule(sch []int, slots []time.Time, tz *time.Location) []int 
 	sort.Ints(out)
 	return out
 }
+
+func runBackfill(cfg *Config, days int, end time.Time, dryRun bool) error {
+	if days <= 0 {
+		return fmt.Errorf("--days must be >= 1, got %d", days)
+	}
+	cfg.Backfill = true
+
+	planHH, planMM, err := parseHHMM(cfg.PlanTime)
+	if err != nil {
+		return fmt.Errorf("POOL_PLAN_TIME parse: %w", err)
+	}
+
+	dates := backfillDates(end, days, cfg.Timezone)
+	results := make([]backfillResult, 0, len(dates))
+
+	for _, d := range dates {
+		anchorLocal := time.Date(d.Year(), d.Month(), d.Day(), planHH, planMM, 0, 0, cfg.Timezone)
+		tags := map[string]string{
+			"run":         "backfill",
+			"anchor_date": d.Format("2006-01-02"),
+		}
+
+		origHost, origToken := "", ""
+		if dryRun {
+			// Blank out credentials so WritePoints no-ops (it checks both
+			// and logs-and-returns). Cheaper than threading a flag through.
+			origHost, origToken = cfg.InfluxHost, cfg.InfluxToken
+			cfg.InfluxHost, cfg.InfluxToken = "", ""
+		}
+		report, planErr := plan(cfg, anchorLocal.UTC(), tags)
+		if dryRun {
+			cfg.InfluxHost, cfg.InfluxToken = origHost, origToken
+		}
+
+		if planErr != nil {
+			results = append(results, backfillResult{Date: d, Mode: "ERR", Err: planErr})
+			continue
+		}
+		results = append(results, backfillResult{
+			Date:        d,
+			Mode:        report.Mode,
+			Hours:       report.Hours,
+			TargetHours: report.TargetHours,
+			CostSEK:     report.CostSEK,
+			SlackHours:  report.SlackHours,
+			Missing:     report.Missing,
+			OnHours:     report.OnHours,
+		})
+	}
+
+	fmt.Print(formatBackfillTable(results, end, cfg.Timezone, cfg.PlanTime))
+
+	anyOK := false
+	for _, r := range results {
+		if r.Err == nil {
+			anyOK = true
+			break
+		}
+	}
+	if !anyOK {
+		return fmt.Errorf("all %d backfill days failed", len(results))
+	}
+	return nil
+}

--- a/pool-pump-planner/backfill_test.go
+++ b/pool-pump-planner/backfill_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBackfillDates(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	got := backfillDates(end, 3, tz)
+	want := []time.Time{
+		time.Date(2026, 4, 18, 0, 0, 0, 0, tz),
+		time.Date(2026, 4, 19, 0, 0, 0, 0, tz),
+		time.Date(2026, 4, 20, 0, 0, 0, 0, tz),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("[%d] got=%s want=%s", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBackfillDatesZeroDays(t *testing.T) {
+	tz := time.UTC
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	got := backfillDates(end, 0, tz)
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestFormatBackfillTable(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)
+	results := []backfillResult{
+		{
+			Date: time.Date(2026, 4, 19, 0, 0, 0, 0, tz),
+			Mode: "optimal", Hours: 6.0, TargetHours: 6, CostSEK: 9.81, SlackHours: 0.0,
+			Missing: "none", OnHours: []int{1, 2, 3, 4, 13, 14},
+		},
+		{
+			Date: time.Date(2026, 4, 20, 0, 0, 0, 0, tz),
+			Mode: "fallback", Hours: 8.0, TargetHours: 8, CostSEK: 18.40, SlackHours: 0.0,
+			Missing: "prices", OnHours: []int{1, 2, 3, 4, 12, 13, 14, 15},
+		},
+	}
+	out := formatBackfillTable(results, end, tz, "14:05")
+	if !strings.Contains(out, "2026-04-20") {
+		t.Errorf("expected 2026-04-20 row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "prices") {
+		t.Errorf("expected 'prices' in missing col, got:\n%s", out)
+	}
+	pos20 := strings.Index(out, "2026-04-20")
+	pos19 := strings.Index(out, "2026-04-19")
+	if pos19 < pos20 || pos20 < 0 {
+		t.Errorf("expected 04-20 before 04-19 (newest first); positions 04-20=%d 04-19=%d\n%s",
+			pos20, pos19, out)
+	}
+	if !strings.Contains(out, "Failures: 0") {
+		t.Errorf("expected 'Failures: 0', got:\n%s", out)
+	}
+}

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -109,6 +109,9 @@ func loadConfig() *Config {
 	if cfg.VMToken == "" {
 		cfg.VMToken = cfg.InfluxToken
 	}
+	if cfg.VMURL == "" {
+		cfg.VMURL = cfg.InfluxHost
+	}
 
 	if err := cfg.validate(); err != nil {
 		log.Fatalf("invalid configuration: %v", err)

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -56,6 +56,10 @@ type Config struct {
 
 	// Runtime flags
 	DryRun bool // print inputs/schedule, skip VictoriaMetrics writes
+
+	// Backfill selects the historical data fetchers (historical solar via VM
+	// instead of forecast.solar). Set only by the backfill subcommand.
+	Backfill bool
 }
 
 func loadConfig() *Config {

--- a/pool-pump-planner/main.go
+++ b/pool-pump-planner/main.go
@@ -13,6 +13,14 @@ import (
 func main() {
 	log.SetFlags(log.LstdFlags | log.LUTC)
 
+	if len(os.Args) >= 2 && os.Args[1] == "backfill" {
+		cfg := loadConfig()
+		if err := backfillCLI(cfg, os.Args[2:]); err != nil {
+			log.Fatalf("backfill: %v", err)
+		}
+		return
+	}
+
 	once := flag.Bool("once", false, "run planner once and exit")
 	dryRun := flag.Bool("dry-run", false, "fetch inputs and compute schedule, print everything, skip write to VictoriaMetrics")
 	flag.Parse()
@@ -42,12 +50,36 @@ func main() {
 	}
 }
 
+// backfillCLI parses subcommand flags and dispatches to runBackfill.
+func backfillCLI(cfg *Config, args []string) error {
+	fs := flag.NewFlagSet("backfill", flag.ExitOnError)
+	days := fs.Int("days", 30, "number of calendar days to backfill")
+	endFlag := fs.String("end", "", "last day to plan (YYYY-MM-DD, site-local) — default: yesterday")
+	dryRun := fs.Bool("dry-run", false, "compute + print the table, skip VM writes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var end time.Time
+	if *endFlag == "" {
+		now := time.Now().In(cfg.Timezone)
+		end = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, cfg.Timezone).AddDate(0, 0, -1)
+	} else {
+		d, err := time.ParseInLocation("2006-01-02", *endFlag, cfg.Timezone)
+		if err != nil {
+			return fmt.Errorf("--end %q: %w", *endFlag, err)
+		}
+		end = d
+	}
+
+	return runBackfill(cfg, *days, end, *dryRun)
+}
+
 func parseHHMM(s string) (int, int, error) {
 	parts := strings.Split(s, ":")
 	if len(parts) != 2 {
 		return 0, 0, fmt.Errorf("expected HH:MM, got %q", s)
 	}
-	// strconv.Atoi rejects empty strings, so ":05" / "14:" / "::" all error out.
 	hh, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid hour %q: %w", parts[0], err)

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -20,24 +20,29 @@ func nan() float64 { return math.NaN() }
 // runPlanner is the top-level entry. Any error is logged so the caller can
 // keep running on a schedule without crashing.
 func runPlanner(cfg *Config) {
-	if err := plan(cfg); err != nil {
+	if err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
 		log.Printf("[planner] run failed: %v", err)
 	}
 }
 
-func plan(cfg *Config) error {
+func plan(cfg *Config, now time.Time, extraTags map[string]string) error {
 	slotMinutes := cfg.SlotMinutes
 	horizonSlots := cfg.HorizonSlots()
 
-	now := time.Now().UTC().Truncate(time.Hour)
+	now = now.UTC().Truncate(time.Hour)
 	slots := make([]time.Time, horizonSlots)
 	for i := 0; i < horizonSlots; i++ {
 		slots[i] = now.Add(time.Duration(i*slotMinutes) * time.Minute)
 	}
 
 	prices := cfg.fetchHourlyPrices(slots)
-	solar := cfg.fetchSolarForecast(slots)
-	waterTemp, waterOK := cfg.fetchWaterTemp()
+	var solar []float64
+	if cfg.Backfill {
+		solar = cfg.fetchSolarHistoricalKWh(slots)
+	} else {
+		solar = cfg.fetchSolarForecast(slots)
+	}
+	waterTemp, waterOK := cfg.fetchWaterTempAt(now)
 
 	if cfg.DryRun {
 		printInputs(cfg, slots, prices, solar, waterTemp, waterOK)
@@ -54,7 +59,7 @@ func plan(cfg *Config) error {
 		sch := fallbackSchedule(cfg, slots)
 		stats := fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing)
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags)
 	}
 
 	targetHours := computeTargetHours(cfg, waterTemp, waterOK)
@@ -67,9 +72,9 @@ func plan(cfg *Config) error {
 		sch = fallbackSchedule(cfg, slots)
 		stats = fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible")
+		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags)
 	}
-	return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "")
+	return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags)
 }
 
 // missingInputs returns a comma-separated list of inputs missing by enough
@@ -254,12 +259,19 @@ func solve(cfg *Config, slots []time.Time, prices, solar []float64, targetHours 
 }
 
 func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
-	waterTemp float64, waterOK bool, targetHours int, mode, missing string) error {
+	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) error {
+	applyTags := func(p *Point) *Point {
+		for k, v := range extraTags {
+			p.Tag(k, v)
+		}
+		return p
+	}
+
 	points := make([]*Point, 0, len(slots)+1)
 	for t, slot := range slots {
-		p := NewPoint("pool_iqpump_plan").
+		p := applyTags(NewPoint("pool_iqpump_plan").
 			Tag("horizon", "24h").
-			Tag("mode", mode).
+			Tag("mode", mode)).
 			Field("on", sch[t]).
 			Field("cost_sek", stats.costPerSlot[t]).
 			At(slot)
@@ -289,10 +301,10 @@ func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float6
 		missingTag = "none"
 	}
 
-	summary := NewPoint("pool_iqpump_plan_summary").
+	summary := applyTags(NewPoint("pool_iqpump_plan_summary").
 		Tag("horizon", "24h").
 		Tag("mode", mode).
-		Tag("missing_inputs", missingTag).
+		Tag("missing_inputs", missingTag)).
 		Field("planned_hours", stats.plannedHours).
 		Field("target_hours", targetHours).
 		Field("slot_minutes", cfg.SlotMinutes).

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -15,17 +15,29 @@ type planStats struct {
 	costPerSlot     []float64
 }
 
+// planReport is the outcome of one plan() invocation, used by the backfill
+// table. Empty/zero fields on error.
+type planReport struct {
+	Mode        string
+	Hours       float64
+	TargetHours int
+	CostSEK     float64
+	SlackHours  float64
+	Missing     string // "none" when nothing missing
+	OnHours     []int  // unique local clock hours where any slot was on
+}
+
 func nan() float64 { return math.NaN() }
 
 // runPlanner is the top-level entry. Any error is logged so the caller can
 // keep running on a schedule without crashing.
 func runPlanner(cfg *Config) {
-	if err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
+	if _, err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
 		log.Printf("[planner] run failed: %v", err)
 	}
 }
 
-func plan(cfg *Config, now time.Time, extraTags map[string]string) error {
+func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, error) {
 	slotMinutes := cfg.SlotMinutes
 	horizonSlots := cfg.HorizonSlots()
 
@@ -59,7 +71,18 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) error {
 		sch := fallbackSchedule(cfg, slots)
 		stats := fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags)
+		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags); err != nil {
+			return planReport{}, err
+		}
+		return planReport{
+			Mode:        "fallback",
+			Hours:       stats.plannedHours,
+			TargetHours: tgt,
+			CostSEK:     stats.expectedCostSEK,
+			SlackHours:  stats.slackHours,
+			Missing:     missing,
+			OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
+		}, nil
 	}
 
 	targetHours := computeTargetHours(cfg, waterTemp, waterOK)
@@ -72,9 +95,31 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) error {
 		sch = fallbackSchedule(cfg, slots)
 		stats = fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags)
+		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags); err != nil {
+			return planReport{}, err
+		}
+		return planReport{
+			Mode:        "fallback",
+			Hours:       stats.plannedHours,
+			TargetHours: tgt,
+			CostSEK:     stats.expectedCostSEK,
+			SlackHours:  stats.slackHours,
+			Missing:     "infeasible",
+			OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
+		}, nil
 	}
-	return writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags)
+	if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags); err != nil {
+		return planReport{}, err
+	}
+	return planReport{
+		Mode:        "optimal",
+		Hours:       stats.plannedHours,
+		TargetHours: targetHours,
+		CostSEK:     stats.expectedCostSEK,
+		SlackHours:  stats.slackHours,
+		Missing:     "none",
+		OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
+	}, nil
 }
 
 // missingInputs returns a comma-separated list of inputs missing by enough

--- a/pool-pump-planner/solar.go
+++ b/pool-pump-planner/solar.go
@@ -75,8 +75,50 @@ func (c *Config) fetchSolarForecast(slots []time.Time) []float64 {
 	return out
 }
 
-// fetchSolarHistoricalKWh is a temporary stub (Task 3 will replace with a real VM query).
-func (c *Config) fetchSolarHistoricalKWh(slots []time.Time) []float64 { return make([]float64, len(slots)) }
+// fetchSolarHistoricalKWh returns PV production (kWh) per slot, derived from
+// the inverter's historical power metric. Used in backfill mode where
+// forecast.solar has no historical endpoint.
+func (c *Config) fetchSolarHistoricalKWh(slots []time.Time) []float64 {
+	out := make([]float64, len(slots))
+	if len(slots) < 2 {
+		return out
+	}
+	slotSeconds := slots[1].Unix() - slots[0].Unix()
+	if slotSeconds <= 0 {
+		slotSeconds = 900
+	}
+	slotRange := fmt.Sprintf("%ds", slotSeconds)
+	promql := `avg_over_time(sigenergy_pv_power_power_kw{string="total"}[` + slotRange + `])`
+	start := slots[0]
+	end := slots[len(slots)-1]
+	result, err := c.queryPromRange(promql, start, end, int(slotSeconds))
+	if err != nil {
+		log.Printf("[planner] historical solar query failed: %v", err)
+		return out
+	}
+	if len(result) == 0 {
+		return out
+	}
+	slotMinutes := int(slotSeconds / 60)
+	return samplesToKWhPerSlot(result[0].Values, slots, slotMinutes)
+}
+
+// samplesToKWhPerSlot buckets kW samples onto slot start-times and converts
+// to kWh assuming each sample represents the avg kW over one slot.
+func samplesToKWhPerSlot(samples []promSample, slots []time.Time, slotMinutes int) []float64 {
+	out := make([]float64, len(slots))
+	slotHours := float64(slotMinutes) / 60.0
+	byTs := make(map[int64]float64, len(samples))
+	for _, s := range samples {
+		byTs[int64(s.Timestamp)] = s.Value
+	}
+	for i, slot := range slots {
+		if v, ok := byTs[slot.Unix()]; ok {
+			out[i] = v * slotHours
+		}
+	}
+	return out
+}
 
 func toFloat(v any) (float64, bool) {
 	switch x := v.(type) {

--- a/pool-pump-planner/solar.go
+++ b/pool-pump-planner/solar.go
@@ -75,6 +75,9 @@ func (c *Config) fetchSolarForecast(slots []time.Time) []float64 {
 	return out
 }
 
+// fetchSolarHistoricalKWh is a temporary stub (Task 3 will replace with a real VM query).
+func (c *Config) fetchSolarHistoricalKWh(slots []time.Time) []float64 { return make([]float64, len(slots)) }
+
 func toFloat(v any) (float64, bool) {
 	switch x := v.(type) {
 	case float64:

--- a/pool-pump-planner/solar_test.go
+++ b/pool-pump-planner/solar_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSamplesToKWhPerSlot(t *testing.T) {
+	start := time.Unix(1700000000, 0).UTC()
+	slotMinutes := 15
+	slots := []time.Time{
+		start,
+		start.Add(15 * time.Minute),
+		start.Add(30 * time.Minute),
+		start.Add(45 * time.Minute),
+	}
+	// Samples: slot 0 = 2 kW, slot 1 = 0.5 kW, slot 2 = (no data), slot 3 = 1 kW.
+	samples := []promSample{
+		{Timestamp: float64(start.Unix()), Value: 2.0},
+		{Timestamp: float64(start.Add(15 * time.Minute).Unix()), Value: 0.5},
+		{Timestamp: float64(start.Add(45 * time.Minute).Unix()), Value: 1.0},
+	}
+	got := samplesToKWhPerSlot(samples, slots, slotMinutes)
+	want := []float64{0.5, 0.125, 0, 0.25}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Errorf("slot %d: got %.4f want %.4f", i, got[i], want[i])
+		}
+	}
+}

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -209,3 +209,6 @@ func (c *Config) fetchWaterTemp() (float64, bool) {
 	}
 	return result[0].Values[0].Value, true
 }
+
+// fetchWaterTempAt is a temporary stub (Task 2 will replace with a real point-in-time query).
+func (c *Config) fetchWaterTempAt(_ time.Time) (float64, bool) { return c.fetchWaterTemp() }

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -43,12 +43,19 @@ func (c *Config) vmBaseURL() string {
 }
 
 func (c *Config) queryPromInstant(promql, lookbackDelta string) ([]promResult, error) {
+	return c.queryPromInstantAt(promql, time.Time{}, lookbackDelta)
+}
+
+func (c *Config) queryPromInstantAt(promql string, at time.Time, lookbackDelta string) ([]promResult, error) {
 	base := c.vmBaseURL()
 	if base == "" {
 		return nil, fmt.Errorf("VictoriaMetrics query URL not configured")
 	}
 	q := url.Values{}
 	q.Set("query", promql)
+	if !at.IsZero() {
+		q.Set("time", strconv.FormatInt(at.Unix(), 10))
+	}
 	if lookbackDelta != "" {
 		q.Set("lookback_delta", lookbackDelta)
 	}
@@ -198,8 +205,8 @@ func (c *Config) fetchHourlyPrices(slots []time.Time) []float64 {
 	return out
 }
 
-func (c *Config) fetchWaterTemp() (float64, bool) {
-	result, err := c.queryPromInstant("pool_temperature_value", "")
+func (c *Config) fetchWaterTempAt(at time.Time) (float64, bool) {
+	result, err := c.queryPromInstantAt("pool_temperature_value", at, "")
 	if err != nil {
 		log.Printf("[planner] water temp query failed: %v", err)
 		return 0, false
@@ -210,5 +217,6 @@ func (c *Config) fetchWaterTemp() (float64, bool) {
 	return result[0].Values[0].Value, true
 }
 
-// fetchWaterTempAt is a temporary stub (Task 2 will replace with a real point-in-time query).
-func (c *Config) fetchWaterTempAt(_ time.Time) (float64, bool) { return c.fetchWaterTemp() }
+func (c *Config) fetchWaterTemp() (float64, bool) {
+	return c.fetchWaterTempAt(time.Time{})
+}


### PR DESCRIPTION
## Summary

Adds `pool-pump-planner backfill` — a one-shot CLI that replays the planner for each of the last N days (default 30), anchored at each day's `POOL_PLAN_TIME`, writes VM points tagged `run=backfill`, and prints a per-day stdout summary table.

Live runs also now carry `run=live` on every plan point. The existing Grafana plan panel is filtered to `{run="live"}` so backfill writes don't pollute the live visualization (dashboard already uploaded, v50).

Historical solar comes from the real PV metric (`sigenergy_pv_power_power_kw{string="total"}`) aggregated per slot — forecast.solar has no real historical endpoint.

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-21-pool-planner-backfill-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-pool-planner-backfill.md`

## Key commits

- `b87c3c0` — refactor `plan(cfg, now, extraTags)` so backfill can run at an arbitrary anchor; live runs tagged `run=live`
- `952bf0c` — `fetchWaterTempAt(t)` via the `&time=` instant-query param
- `52bcbe5` — `fetchSolarHistoricalKWh(slots)` via `avg_over_time(sigenergy_pv_power_power_kw{string="total"}[<slot>])`
- `9294a93` — `backfill.go` types, date iterator, table formatter (+ tests)
- `9b29238` — `runBackfill()` orchestration + `planReport` return type
- `4ceaa13` — `backfill` subcommand dispatcher in `main.go`
- `c1a5731` — Grafana pool-plan panel filtered to `{run="live"}`
- `497acd8` — Promote `INFLUX_HOST` → `VMURL` at load so `--dry-run` can blank write creds without breaking reads

## Test plan

Local (pre-merge):

- [x] `go build ./pool-pump-planner/...` passes
- [x] `go test ./pool-pump-planner/...` passes (6 tests)
- [x] `go run . backfill -days=3 -dry-run` prints a 3-row table, 0 VM writes
- [x] `go run . backfill -days=3` writes tagged points; VM confirms 3 backfill series (one per `anchor_date`)
- [x] `go run . backfill` 30-day run completes — 28 optimal + 2 fallback, avg 6.13h/day
- [x] Grafana dashboard uploaded (v50)

Post-merge:

- [ ] Redeploy pool-pump-planner on rpi5 so live runs start emitting `run=live` tag
- [ ] Verify Grafana "Poolpump plan" panel only shows `run=live` series
- [ ] Ad-hoc query on `{run="backfill", anchor_date=...}` returns each backfilled day

## Follow-up (not in this PR)

**PV shadow mask for the live planner.** The inverter curve shows morning shade until ~10h and a peak at 14h (vs solar noon ~13h). forecast.solar's symmetric bell overstates morning production. Spec includes a proposal for `POOL_SOLAR_HOURLY_MASK` env var.