### PR TITLE
fix(grafana): tighten pool-plan panel to run=live only

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -102,13 +102,14 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('price_sek_per_kwh', 'Spotpris (SEK/kWh)', 'yellow'),
       overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
     ])
-    // run!="backfill" matches both untagged legacy writes and the new run="live"
-    // tag. max() wrapper collapses multiple series that differ on mode/run
-    // (e.g. an optimal series from today and a fallback series from an older
-    // day) into one line on the plot.
-    .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run!="backfill"}[$__interval]))', 'on'))
-    .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run!="backfill"}[$__interval]))', 'price_sek_per_kwh'))
-    .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run!="backfill"}[$__interval]))', 'solar_kwh'))
+    // Strictly run="live" — the untagged legacy series in VM is a fossil
+    // mixture of points from older deployments (e.g. when slot-size was 30m)
+    // and would otherwise conflict with the current plan at overlapping
+    // timestamps. max() collapses any remaining mode-variants (optimal vs
+    // fallback on the same day) into one line.
+    .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run="live"}[$__interval]))', 'on'))
+    .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval]))', 'price_sek_per_kwh'))
+    .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval]))', 'solar_kwh'))
     // Lock the panel to a fixed calendar-day window: today 00:00 -> 24:00.
     // Grafana rejects negative timeShift, so a rolling now-24h..now+24h window
     // isn't reachable at the panel level. This calendar-day form is the


### PR DESCRIPTION
## Summary

The `Poolpump plan (24h)` panel was flickering 0/1/0/1 in the late-hours window. Root cause: the filter `{run!="backfill"}` was matching **two** series — the new `run=live` series written by the refactored planner AND the old untagged legacy series. The untagged series is a fossil: it holds points from earlier deployments (e.g. slot=30m era at `:00`/`:30`) and later 15m-era points at `:15`/`:45` that never overwrote each other. Under `max()` the two schedules disagreed every other slot.

Tightening the filter to `{run="live"}` excludes the untagged fossil. The untagged points stay in VM (harmless) but no longer pollute the panel.

## Test plan

- [x] Dashboard regenerated + uploaded (v55); panel now shows a single clean line from the `run=live` series only
- [ ] Visually verify on https://irisgatan.grafana.net/d/irisgatan-v3 after merge