### PR TITLE
fix(grafana): split Poolpump backfill panel into dual axes

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -125,15 +125,32 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
   const pumpPlanBackfill = new TimeseriesBuilder()
     .title('Poolpump plan (30 dagar backfill)')
     .datasource(VM_DS)
+    .unit('currencySEK')
     .colorScheme(paletteColor())
     .thresholds(greenThreshold())
     .legend(legendBottom())
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
     .overrides([
-      overrideDisplayAndColor('planned_hours', 'Planerade timmar', 'blue'),
+      {
+        matcher: { id: 'byName', options: 'planned_hours' },
+        properties: [
+          { id: 'displayName', value: 'Planerade timmar' },
+          { id: 'color', value: { fixedColor: 'blue', mode: 'fixed' } },
+          { id: 'custom.axisPlacement', value: 'right' },
+          { id: 'unit', value: 'h' },
+        ],
+      },
       overrideDisplayAndColor('expected_cost_sek', 'Förväntad kostnad (SEK)', 'yellow'),
-      overrideDisplayAndColor('slack_hours', 'Slack (h)', 'orange'),
+      {
+        matcher: { id: 'byName', options: 'slack_hours' },
+        properties: [
+          { id: 'displayName', value: 'Slack (h)' },
+          { id: 'color', value: { fixedColor: 'orange', mode: 'fixed' } },
+          { id: 'custom.axisPlacement', value: 'right' },
+          { id: 'unit', value: 'h' },
+        ],
+      },
     ])
     .withTarget(vmExpr('A', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run="backfill"})', 'planned_hours'))
     .withTarget(vmExpr('B', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="backfill"})', 'expected_cost_sek'))


### PR DESCRIPTION
## Summary
Split the "Poolpump plan (30 dagar backfill)" panel into dual axes so hours aren't squashed against the 0–30 SEK range:
- **Left axis**: Förväntad kostnad (SEK) — panel default unit now `currencySEK`
- **Right axis**: Planerade timmar + Slack, unit `h` — via field overrides

## Test plan
### Local (done)
- [x] Regenerated `grafana/dist/dashboard.json` with Node 25 via `npm run build`; confirmed `defaults.unit = currencySEK`, `planned_hours` and `slack_hours` have `custom.axisPlacement: right` + `unit: h`, and `expected_cost_sek` inherits the SEK left axis.

### Post-merge E2E
- [ ] Upload the regenerated dashboard (`cd grafana && npm run generate`) or let CI push it
- [ ] Open the panel in Grafana, confirm two y-axes: SEK on the left, h on the right
- [ ] Tooltip shows correct units per series
- [ ] Other pool panels render unchanged