### PR TITLE
feat(pool-pump-planner): drop default POOL_BLOCKED_HOURS

### DIFF
--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -86,7 +86,13 @@ func loadConfig() *Config {
 		TargetHours:  getenvInt("POOL_TARGET_HOURS", 6),
 		MaxHours:     getenvInt("POOL_MAX_HOURS", 10),
 		MaxStarts:    getenvInt("POOL_MAX_STARTS", 2),
-		BlockedHours: getenvIntList("POOL_BLOCKED_HOURS", []int{7, 8, 17, 18, 19, 20}),
+		// Default: no blocked hours. 30-day backfill showed the spot-price
+		// signal already avoids peak consumption windows 63% of the time on
+		// its own, and on the other 37% the hard block forces a more expensive
+		// pick — including one infeasible day where 17h was both blocked and
+		// the cheapest hour of the day. Still overridable via env var for
+		// non-economic reasons (noise, effekttariff) if they ever apply.
+		BlockedHours: getenvIntList("POOL_BLOCKED_HOURS", nil),
 
 		FallbackNightHours:     getenvIntList("POOL_FALLBACK_NIGHT_HOURS", []int{1, 2, 3, 4}),
 		FallbackAfternoonHours: getenvIntList("POOL_FALLBACK_AFTERNOON_HOURS", []int{12, 13, 14, 15}),


### PR DESCRIPTION
## Summary

Default `POOL_BLOCKED_HOURS` to empty. The 30-day backfill analysis showed the hard block on 7-8h / 17-20h is net-negative:

- **19/30 days**: spot-price signal alone already avoids those hours — constraint is redundant.
- **11/30 days**: the block forces the planner to a more expensive pick (~47 cheap slots rejected across the month).
- **2026-04-09 (the only infeasible day in the backfill)**: 17h was both blocked and the cheapest hour of the day (0.32 SEK/kWh with 16h at 0.05 and 14-15h at 0.14-0.22). With MaxStarts=2 the MILP couldn't arrange 6h → fell to 8h fallback at 30.59 SEK — the most expensive day of the month.

None of the three non-economic reasons to keep blocked hours currently apply for this deployment:

1. **Noise** — pump has a silent mode (potential future flag, out of scope here)
2. **Effektavgift** — not in current E.ON contract
3. **Time-of-use transfer fee** — current config uses a flat `TransferFeeSEKPerKWh`

Env var is still respected, so the feature remains available if any of those change.

## Test plan

- [x] `go build ./...` — green
- [x] `go test -count=1 ./pool-pump-planner/...` — green (existing `TestWriteLPRoundtrip` uses the lower-level `blocked` map directly, unaffected)
- [ ] Post-merge: watch the next live plan — should still avoid 7-8h and 17-20h on expensive days, but may now legitimately run during those hours when they're cheap. Re-run backfill after a month to confirm the 2026-04-09-style infeasibility is gone.

## Follow-ups (not in this PR)

- Silent-mode scheduling: separate plan to use pump's quiet mode when running during ergonomically-sensitive hours, if that ever becomes relevant.
- PV shadow mask for live `forecast.solar` path (historical backfill doesn't need it — measured PV already has shade baked in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)