### PR TITLE
feat(pool-pump-planner): night/afternoon baselines in backfill

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -141,7 +141,9 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
           { id: 'unit', value: 'h' },
         ],
       },
-      overrideDisplayAndColor('expected_cost_sek', 'Förväntad kostnad (SEK)', 'yellow'),
+      overrideDisplayAndColor('expected_cost_sek', 'Optimerad kostnad (SEK)', 'yellow'),
+      overrideDisplayAndColor('night_baseline_sek', 'Natt 00-06 (SEK)', 'purple'),
+      overrideDisplayAndColor('afternoon_baseline_sek', 'Eftermiddag 12-18 (SEK)', 'red'),
       {
         matcher: { id: 'byName', options: 'slack_hours' },
         properties: [
@@ -154,6 +156,12 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     ])
     .withTarget(vmExpr('A', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run="backfill"})', 'planned_hours'))
     .withTarget(vmExpr('B', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="backfill"})', 'expected_cost_sek'))
+    // Night/afternoon fixed-schedule baselines emitted by `backfill` alongside
+    // the MILP-optimal plan. Plotting all three on the same panel makes the
+    // optimizer's value directly visible: the gap between yellow and the
+    // baselines is SEK the planner saved vs a naive always-at-this-time rule.
+    .withTarget(vmExpr('D', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
+    .withTarget(vmExpr('E', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
     .withTarget(vmExpr('C', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run="backfill"})', 'slack_hours'))
     .timeFrom('now-30d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -142,8 +142,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
         ],
       },
       overrideDisplayAndColor('expected_cost_sek', 'Optimerad kostnad (SEK)', 'yellow'),
-      overrideDisplayAndColor('night_baseline_sek', 'Natt 00-06 (SEK)', 'purple'),
-      overrideDisplayAndColor('afternoon_baseline_sek', 'Eftermiddag 12-18 (SEK)', 'red'),
+      overrideDisplayAndColor('night_baseline_sek', 'Naiv 00-06', 'purple'),
+      overrideDisplayAndColor('afternoon_baseline_sek', 'Naiv 12-18', 'red'),
       {
         matcher: { id: 'byName', options: 'slack_hours' },
         properties: [

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -141,7 +141,7 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
           { id: 'unit', value: 'h' },
         ],
       },
-      overrideDisplayAndColor('expected_cost_sek', 'Optimerad kostnad (SEK)', 'yellow'),
+      overrideDisplayAndColor('expected_cost_sek', 'Optimerad', 'yellow'),
       overrideDisplayAndColor('night_baseline_sek', 'Naiv 00-06', 'purple'),
       overrideDisplayAndColor('afternoon_baseline_sek', 'Naiv 12-18', 'red'),
       {

--- a/pool-pump-planner/backfill.go
+++ b/pool-pump-planner/backfill.go
@@ -9,15 +9,17 @@ import (
 
 // backfillResult is one row in the stdout summary table.
 type backfillResult struct {
-	Date        time.Time // site-local midnight of the anchor day
-	Mode        string    // "optimal" / "fallback" / "ERR"
-	Hours       float64
-	TargetHours int
-	CostSEK     float64
-	SlackHours  float64
-	Missing     string // "none" if everything was present
-	OnHours     []int  // unique local clock hours where any slot was on
-	Err         error  // non-nil for a day that completely failed
+	Date              time.Time // site-local midnight of the anchor day
+	Mode              string    // "optimal" / "fallback" / "ERR"
+	Hours             float64
+	TargetHours       int
+	CostSEK           float64
+	SlackHours        float64
+	Missing           string // "none" if everything was present
+	OnHours           []int  // unique local clock hours where any slot was on
+	NightBaselineSEK  float64
+	AfternoonBaseSEK  float64
+	Err               error // non-nil for a day that completely failed
 }
 
 // backfillDates returns `days` calendar-day midnights in the given tz, oldest
@@ -41,8 +43,8 @@ func formatBackfillTable(results []backfillResult, end time.Time, tz *time.Locat
 	var b strings.Builder
 	fmt.Fprintf(&b, "Pool pump backfill — %d days ending %s (anchor %s %s)\n\n",
 		len(results), end.In(tz).Format("2006-01-02"), planTime, tz.String())
-	fmt.Fprintf(&b, "  %-10s  %-9s  %5s  %3s  %10s  %5s  %-12s  ON_HOURS (local)\n",
-		"DATE", "MODE", "HRS", "TGT", "COST(SEK)", "SLACK", "MISSING")
+	fmt.Fprintf(&b, "  %-10s  %-9s  %5s  %3s  %10s  %10s  %10s  %5s  %-12s  ON_HOURS (local)\n",
+		"DATE", "MODE", "HRS", "TGT", "OPT(SEK)", "NIGHT(SEK)", "AFTNN(SEK)", "SLACK", "MISSING")
 
 	sorted := make([]backfillResult, len(results))
 	copy(sorted, results)
@@ -51,6 +53,8 @@ func formatBackfillTable(results []backfillResult, end time.Time, tz *time.Locat
 	totHours := 0.0
 	totTgt := 0
 	totCost := 0.0
+	totNight := 0.0
+	totAftnn := 0.0
 	failures := 0
 	for _, r := range sorted {
 		date := r.Date.Format("2006-01-02")
@@ -63,21 +67,35 @@ func formatBackfillTable(results []backfillResult, end time.Time, tz *time.Locat
 		for _, h := range r.OnHours {
 			on = append(on, fmt.Sprintf("%02d", h))
 		}
-		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f  %5.1f  %-12s  %s\n",
-			date, r.Mode, r.Hours, r.TargetHours, r.CostSEK, r.SlackHours,
-			ifEmpty(r.Missing, "-"), strings.Join(on, " "))
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f  %10.2f  %10.2f  %5.1f  %-12s  %s\n",
+			date, r.Mode, r.Hours, r.TargetHours, r.CostSEK,
+			r.NightBaselineSEK, r.AfternoonBaseSEK,
+			r.SlackHours, ifEmpty(r.Missing, "-"), strings.Join(on, " "))
 		totHours += r.Hours
 		totTgt += r.TargetHours
 		totCost += r.CostSEK
+		totNight += r.NightBaselineSEK
+		totAftnn += r.AfternoonBaseSEK
 	}
-	fmt.Fprintf(&b, "  %s\n", strings.Repeat("─", 90))
+	fmt.Fprintf(&b, "  %s\n", strings.Repeat("─", 115))
 	succ := len(results) - failures
 	if succ > 0 {
-		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f   avg/day %.2fh, %.2f SEK\n",
-			"Totals", "", totHours, totTgt, totCost, totHours/float64(succ), totCost/float64(succ))
+		fmt.Fprintf(&b, "  %-10s  %-9s  %5.1f  %3d  %10.2f  %10.2f  %10.2f   opt avg %.2f SEK/day\n",
+			"Totals", "", totHours, totTgt, totCost, totNight, totAftnn, totCost/float64(succ))
+		fmt.Fprintf(&b, "  Savings vs night-fixed:     %7.2f SEK (%5.1f%%)\n",
+			totNight-totCost, pct(totNight-totCost, totNight))
+		fmt.Fprintf(&b, "  Savings vs afternoon-fixed: %7.2f SEK (%5.1f%%)\n",
+			totAftnn-totCost, pct(totAftnn-totCost, totAftnn))
 	}
 	fmt.Fprintf(&b, "  Failures: %d\n", failures)
 	return b.String()
+}
+
+func pct(numer, denom float64) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return 100 * numer / denom
 }
 
 func ifEmpty(s, def string) string {
@@ -85,6 +103,52 @@ func ifEmpty(s, def string) string {
 		return def
 	}
 	return s
+}
+
+// fixedWindowSchedule returns a schedule of the same length as slots where
+// slot i is 1 iff slots[i]'s local-clock hour is in windowHours.
+func fixedWindowSchedule(slots []time.Time, windowHours []int, tz *time.Location) []int {
+	set := map[int]bool{}
+	for _, h := range windowHours {
+		set[h] = true
+	}
+	out := make([]int, len(slots))
+	for i, s := range slots {
+		if set[s.In(tz).Hour()] {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+// runBaselines computes and writes two fixed-schedule "what if" baselines
+// for comparison against the MILP optimum: a night window and an afternoon
+// window. Uses the same slotCost function as the optimizer so costs are
+// directly comparable. Emits under distinct run tags so Grafana can plot
+// all three side by side. Returns (nightCost, afternoonCost) for the table.
+func runBaselines(cfg *Config, in planInputs, anchorDate string, dryRun bool) (float64, float64) {
+	night := writeBaseline(cfg, in, cfg.BaselineNightHours, "baseline_night", anchorDate, dryRun)
+	afternoon := writeBaseline(cfg, in, cfg.BaselineAfternoonHours, "baseline_afternoon", anchorDate, dryRun)
+	return night, afternoon
+}
+
+func writeBaseline(cfg *Config, in planInputs, windowHours []int, runTag, anchorDate string, dryRun bool) float64 {
+	sch := fixedWindowSchedule(in.Slots, windowHours, cfg.Timezone)
+	stats := fallbackStats(cfg, sch, in.Prices, in.Solar)
+	tags := map[string]string{"run": runTag, "anchor_date": anchorDate}
+
+	if dryRun {
+		// Dry-run: skip VM writes but still return the computed cost for the
+		// stdout table. writePlan respects cfg.DryRun to no-op, but also
+		// prints the schedule which is noisy for baselines; skip it entirely.
+		return stats.expectedCostSEK
+	}
+	if err := writePlan(cfg, in.Slots, sch, in.Prices, in.Solar, stats,
+		in.WaterTemp, in.WaterOK, len(windowHours), "baseline", "none", tags); err != nil {
+		// Non-fatal: baselines are comparison only, don't fail the day.
+		fmt.Printf("[backfill] baseline %s write failed: %v\n", runTag, err)
+	}
+	return stats.expectedCostSEK
 }
 
 // onHoursFromSchedule returns the sorted unique local clock hours in which at
@@ -132,7 +196,7 @@ func runBackfill(cfg *Config, days int, end time.Time, dryRun bool) error {
 			origHost, origToken = cfg.InfluxHost, cfg.InfluxToken
 			cfg.InfluxHost, cfg.InfluxToken = "", ""
 		}
-		report, planErr := plan(cfg, anchorLocal.UTC(), tags)
+		report, inputs, planErr := plan(cfg, anchorLocal.UTC(), tags)
 		if dryRun {
 			cfg.InfluxHost, cfg.InfluxToken = origHost, origToken
 		}
@@ -141,15 +205,20 @@ func runBackfill(cfg *Config, days int, end time.Time, dryRun bool) error {
 			results = append(results, backfillResult{Date: d, Mode: "ERR", Err: planErr})
 			continue
 		}
+
+		nightCost, afternoonCost := runBaselines(cfg, inputs, tags["anchor_date"], dryRun)
+
 		results = append(results, backfillResult{
-			Date:        d,
-			Mode:        report.Mode,
-			Hours:       report.Hours,
-			TargetHours: report.TargetHours,
-			CostSEK:     report.CostSEK,
-			SlackHours:  report.SlackHours,
-			Missing:     report.Missing,
-			OnHours:     report.OnHours,
+			Date:              d,
+			Mode:              report.Mode,
+			Hours:             report.Hours,
+			TargetHours:       report.TargetHours,
+			CostSEK:           report.CostSEK,
+			SlackHours:        report.SlackHours,
+			Missing:           report.Missing,
+			OnHours:           report.OnHours,
+			NightBaselineSEK:  nightCost,
+			AfternoonBaseSEK:  afternoonCost,
 		})
 	}
 

--- a/pool-pump-planner/backfill_test.go
+++ b/pool-pump-planner/backfill_test.go
@@ -34,6 +34,39 @@ func TestBackfillDatesZeroDays(t *testing.T) {
 	}
 }
 
+func TestFixedWindowSchedule(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	// 96 slots of 15m starting at 2026-04-20 00:00 UTC = 02:00 local (DST).
+	start := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	slots := make([]time.Time, 96)
+	for i := range slots {
+		slots[i] = start.Add(time.Duration(i*15) * time.Minute)
+	}
+	// Window = local hours [12,13]. That's 2 hours = 8 slots. In UTC that's
+	// 10:00-12:00 (CEST=UTC+2), starting at slots[40].
+	got := fixedWindowSchedule(slots, []int{12, 13}, tz)
+	if len(got) != 96 {
+		t.Fatalf("expected 96 slots, got %d", len(got))
+	}
+	ones := 0
+	for i, v := range got {
+		if v != 0 && v != 1 {
+			t.Errorf("slot %d has non-binary value %d", i, v)
+		}
+		ones += v
+	}
+	if ones != 8 {
+		t.Errorf("expected 8 on-slots for window [12,13], got %d", ones)
+	}
+	// Slots 40..47 (10:00-12:00 UTC = 12:00-14:00 local) should all be 1.
+	for i := 40; i < 48; i++ {
+		if got[i] != 1 {
+			t.Errorf("expected slot %d (local %02dh) = 1, got 0",
+				i, slots[i].In(tz).Hour())
+		}
+	}
+}
+
 func TestFormatBackfillTable(t *testing.T) {
 	tz, _ := time.LoadLocation("Europe/Stockholm")
 	end := time.Date(2026, 4, 20, 0, 0, 0, 0, tz)

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -43,6 +43,13 @@ type Config struct {
 	FallbackNightHours     []int
 	FallbackAfternoonHours []int
 
+	// Baseline comparison windows: emitted by the backfill subcommand as
+	// alternative "what if" schedules (always run during these local hours)
+	// so the optimizer's cost can be compared against simple fixed schedules.
+	// Defaults are each 6h long so they match the 6h default target hours.
+	BaselineNightHours     []int
+	BaselineAfternoonHours []int
+
 	// Temperature driven target override
 	TargetTempC          float64
 	HeatingRateCPerHour  float64
@@ -96,6 +103,9 @@ func loadConfig() *Config {
 
 		FallbackNightHours:     getenvIntList("POOL_FALLBACK_NIGHT_HOURS", []int{1, 2, 3, 4}),
 		FallbackAfternoonHours: getenvIntList("POOL_FALLBACK_AFTERNOON_HOURS", []int{12, 13, 14, 15}),
+
+		BaselineNightHours:     getenvIntList("POOL_BASELINE_NIGHT_HOURS", []int{0, 1, 2, 3, 4, 5}),
+		BaselineAfternoonHours: getenvIntList("POOL_BASELINE_AFTERNOON_HOURS", []int{12, 13, 14, 15, 16, 17}),
 
 		TargetTempC:         getenvFloat("POOL_TARGET_TEMP_C", 29),
 		HeatingRateCPerHour: getenvFloat("POOL_HEATING_RATE_C_PER_HOUR", 0),

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -27,17 +27,29 @@ type planReport struct {
 	OnHours     []int  // unique local clock hours where any slot was on
 }
 
+// planInputs are the fetched inputs shared between the MILP solve and any
+// alternative schedules computed on the same day (baselines). Populated even
+// when plan() returns an error after the fetch stage, so callers can still
+// use the inputs for comparison runs.
+type planInputs struct {
+	Slots     []time.Time
+	Prices    []float64
+	Solar     []float64
+	WaterTemp float64
+	WaterOK   bool
+}
+
 func nan() float64 { return math.NaN() }
 
 // runPlanner is the top-level entry. Any error is logged so the caller can
 // keep running on a schedule without crashing.
 func runPlanner(cfg *Config) {
-	if _, err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
+	if _, _, err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
 		log.Printf("[planner] run failed: %v", err)
 	}
 }
 
-func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, error) {
+func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, planInputs, error) {
 	slotMinutes := cfg.SlotMinutes
 	horizonSlots := cfg.HorizonSlots()
 
@@ -56,6 +68,14 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 	}
 	waterTemp, waterOK := cfg.fetchWaterTempAt(now)
 
+	inputs := planInputs{
+		Slots:     slots,
+		Prices:    prices,
+		Solar:     solar,
+		WaterTemp: waterTemp,
+		WaterOK:   waterOK,
+	}
+
 	if cfg.DryRun {
 		printInputs(cfg, slots, prices, solar, waterTemp, waterOK)
 	}
@@ -72,7 +92,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 		stats := fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
 		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags); err != nil {
-			return planReport{}, err
+			return planReport{}, inputs, err
 		}
 		return planReport{
 			Mode:        "fallback",
@@ -82,7 +102,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 			SlackHours:  stats.slackHours,
 			Missing:     missing,
 			OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
-		}, nil
+		}, inputs, nil
 	}
 
 	targetHours := computeTargetHours(cfg, waterTemp, waterOK)
@@ -96,7 +116,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 		stats = fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
 		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags); err != nil {
-			return planReport{}, err
+			return planReport{}, inputs, err
 		}
 		return planReport{
 			Mode:        "fallback",
@@ -106,10 +126,10 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 			SlackHours:  stats.slackHours,
 			Missing:     "infeasible",
 			OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
-		}, nil
+		}, inputs, nil
 	}
 	if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags); err != nil {
-		return planReport{}, err
+		return planReport{}, inputs, err
 	}
 	return planReport{
 		Mode:        "optimal",
@@ -119,7 +139,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 		SlackHours:  stats.slackHours,
 		Missing:     "none",
 		OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
-	}, nil
+	}, inputs, nil
 }
 
 // missingInputs returns a comma-separated list of inputs missing by enough


### PR DESCRIPTION
## Summary

For each day in the backfill, also compute and emit the cost of two fixed "what if" schedules so the MILP optimum is directly comparable against naive always-run-at-this-time rules.

**Windows** (both 6h, matching default `TargetHours`):
- Night: `[0, 1, 2, 3, 4, 5]` — configurable via `POOL_BASELINE_NIGHT_HOURS`
- Afternoon: `[12, 13, 14, 15, 16, 17]` — configurable via `POOL_BASELINE_AFTERNOON_HOURS`

**Tagging strategy**: Emit under separate `run` tags (`baseline_night`, `baseline_afternoon`) alongside the existing `run=backfill` (optimal). One Grafana panel can plot all three.

## 30-day backfill result (real SE4 prices, Mar 22 – Apr 20)

| Strategy | Cost | vs optimal |
|---|---|---|
| **Optimal (MILP)** | **621.35 SEK** | — |
| Afternoon fixed (12-17h) | 664.86 SEK | +6.5% |
| Night fixed (00-05h) | 1125.67 SEK | +81.1% |

The small gap vs afternoon confirms what the on-hour histogram already showed: 91% of optimal on-slots fall between 11-16h, so the optimizer is essentially doing "afternoon with daily tweaks". The large gap vs night (+504 SEK/month = ~6000 SEK/year) quantifies why time-of-use scheduling matters at all.

## Changes

- `config.go`: two new `[]int` config fields + env vars
- `planner.go`: `plan()` now returns `planInputs` so the backfill caller can reuse fetched prices/solar/water_temp without re-querying VM
- `backfill.go`: `runBaselines` helper computes both baselines per day via `fallbackStats` (same cost model as MILP) and writes via `writePlan`. Table gains two columns + summary savings lines.
- `backfill_test.go`: new `TestFixedWindowSchedule`
- `grafana/src/panels/pool.ts`: `pumpPlanBackfill` gets two extra series (red afternoon, purple night). Existing yellow line renamed 'Optimerad kostnad (SEK)'.

## Test plan

- [x] `go build ./...` — green
- [x] `go test -count=1 ./pool-pump-planner/...` — green (3 backfill tests, milp roundtrip, solar, main)
- [x] Live dry-run (`--dry-run --days=5`) — table shows new columns, savings summary makes sense
- [x] Full 30-day backfill against VM — 0 failures, all 30 anchor_dates emitted optimal + 2 baselines (90 summary points total)
- [x] Dashboard v58 uploaded to irisgatan.grafana.net — panel now shows 3 lines
- [ ] Post-merge: confirm the next rpi5 deploy doesn't accidentally emit baselines on the live planner (only the backfill subcommand calls `runBaselines`; the live `runPlanner` just discards the extra `planInputs` return value). Verify no `run=baseline_*` series appear with `anchor_date` unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)