### PR TITLE
feat(webui): rename Batteri SOC to Hem Batteri, move beside XC40

### DIFF
--- a/fetcher-core/webui/app/lib/values.ts
+++ b/fetcher-core/webui/app/lib/values.ts
@@ -16,6 +16,7 @@ export const values: Config = [
     [
         { measurement: 'tibber', field: 'accumulatedCost', title: 'Dygnskostnad', unit: 'Kr', decimals: 0, sparkline: '24h', sparklineMin: 0 },
         { measurement: 'tibber', field: 'accumulatedConsumption', title: 'Dygnskonsumtion', unit: 'KWh', decimals: 0, sparkline: '24h', sparklineMin: 0 },
+        { measurement: 'sigenergy_battery', field: 'soc_percent', title: '🏡 Hem Batteri', unit: '%', decimals: 0, reload: 60000, sparkline: '24h', sparklineMin: 0, sparklineMax: 100 },
         { measurement: 'ha_volvo_xc40_battery', field: 'value', title: '🚗 XC40 Batteri', unit: '%', decimals: 0, reload: 60000, sparkline: '24h', sparklineMin: 0, sparklineMax: 100 },
         { measurement: 'ha_volvo_xc40_charging_power', field: 'value', title: '🔌 XC40 Laddning', unit: 'kW', decimals: 1, reload: 60000, sparkline: '24h', sparklineMin: 0 },
     ],
@@ -25,7 +26,6 @@ export const values: Config = [
         { measurement: 'sigenergy_home', field: 'load_kw',
          expr: 'clamp_min(sigenergy_pv_power_power_kw{string="total"} + on(host) sigenergy_grid_power_net_power_kw + on(host) sigenergy_battery_power_from_battery_kw, 0)',
          title: '🏠 Förbrukning', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: 0, sparklineMax: 5 },
-        { measurement: 'sigenergy_battery', field: 'soc_percent', title: '🔋 Batteri SOC', unit: '%', decimals: 0, reload: 60000, sparkline: '24h', sparklineMin: 0, sparklineMax: 100 },
         { measurement: 'sigenergy_battery', field: 'power_from_battery_kw',
          expr: 'clamp_min(sigenergy_battery_power_from_battery_kw, 0)',
          title: '🪫 Batteri Urladdning', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: 0, sparklineMax: 10 },


### PR DESCRIPTION
## Summary
- Rename the battery SOC tile from `🔋 Batteri SOC` to `🏡 Hem Batteri`.
- Move it from the last row into the third row, just before `🚗 XC40 Batteri`, so home and car battery SOC sit side by side.

## Test plan
- [ ] `cd fetcher-core/webui && npm run dev`, open the dashboard, confirm row 3 shows `🏡 Hem Batteri` immediately before `🚗 XC40 Batteri`.
- [ ] Confirm the last row no longer contains a Batteri SOC tile, but still renders Urladdning / Laddning.
- [ ] Sparkline + value render for the renamed tile.