### PR TITLE
feat(pool-pump-planner): snapshot-semantics for run=live writes

### DIFF
--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -386,6 +386,18 @@ func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float6
 		return nil
 	}
 
+	// Clean snapshot for live runs: delete previous {run="live"} samples within
+	// this plan's horizon (slots[0] forward). Forward-only scoping preserves
+	// live-plan records from earlier days. Backfill/baseline paths are untouched
+	// because they use run="backfill"/"baseline_*". Log-and-continue on error —
+	// a delete failure is no worse than the pre-fix duplicate state.
+	if extraTags["run"] == "live" && len(slots) > 0 {
+		sel := `{__name__=~"pool_iqpump_plan.*",run="live"}`
+		if err := cfg.deleteSeries(sel, slots[0]); err != nil {
+			log.Printf("[planner] delete_series failed (continuing): %v", err)
+		}
+	}
+
 	if err := cfg.WritePoints(points); err != nil {
 		return err
 	}

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -133,6 +133,43 @@ func (c *Config) promGet(u string, rangeQuery bool) ([]promResult, error) {
 	return out, nil
 }
 
+// deleteSeries calls VictoriaMetrics' admin delete_series endpoint with a
+// Prometheus label matcher. When start is non-zero, the delete is scoped to
+// samples with timestamp >= start (VM supports Prom's start param on this
+// endpoint). Uses Bearer auth via VMToken, same as promGet. Idempotent —
+// selectors matching no series return 204.
+func (c *Config) deleteSeries(matcher string, start time.Time) error {
+	base := c.vmBaseURL()
+	if base == "" {
+		return fmt.Errorf("VictoriaMetrics delete URL not configured")
+	}
+	q := url.Values{}
+	q.Add("match[]", matcher)
+	if !start.IsZero() {
+		q.Add("start", strconv.FormatInt(start.Unix(), 10))
+	}
+	req, err := http.NewRequest("POST", base+"/api/v1/admin/tsdb/delete_series",
+		strings.NewReader(q.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if c.VMToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.VMToken)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("vm delete_series %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
 func parseSample(v []any) (promSample, bool) {
 	if len(v) != 2 {
 		return promSample{}, false

--- a/pool-pump-planner/vm_test.go
+++ b/pool-pump-planner/vm_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDeleteSeries_Success(t *testing.T) {
+	start := time.Date(2026, 4, 21, 14, 0, 0, 0, time.UTC)
+	var called atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/admin/tsdb/delete_series" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("auth = %q", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if matches := r.PostForm["match[]"]; len(matches) != 1 ||
+			matches[0] != `{__name__=~"pool_iqpump_plan.*",run="live"}` {
+			t.Errorf("match[] = %v", matches)
+		}
+		if got, want := r.PostForm.Get("start"), strconv.FormatInt(start.Unix(), 10); got != want {
+			t.Errorf("start = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfg := &Config{VMURL: srv.URL, VMToken: "test-token"}
+	if err := cfg.deleteSeries(`{__name__=~"pool_iqpump_plan.*",run="live"}`, start); err != nil {
+		t.Fatalf("deleteSeries: %v", err)
+	}
+	if called.Load() != 1 {
+		t.Errorf("handler called %d times, want 1", called.Load())
+	}
+}
+
+func TestDeleteSeries_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("perm denied"))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{VMURL: srv.URL, VMToken: "tok"}
+	err := cfg.deleteSeries(`{run="live"}`, time.Time{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") || !strings.Contains(err.Error(), "perm denied") {
+		t.Errorf("error = %v, want mention of 500 + body", err)
+	}
+}
+
+func TestDeleteSeries_OmitsStartWhenZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.PostForm.Has("start") {
+			t.Errorf("start should be omitted for zero time, got %q", r.PostForm.Get("start"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfg := &Config{VMURL: srv.URL, VMToken: "tok"}
+	if err := cfg.deleteSeries(`{run="live"}`, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writePlan fixture setup: a single mock server handles both the delete and
+// write endpoints. Counts per-endpoint so tests can assert whether delete was
+// called for a given run tag.
+type writePlanMock struct {
+	server      *httptest.Server
+	deleteCalls atomic.Int32
+	writeCalls  atomic.Int32
+	deleteStart atomic.Int64
+}
+
+func newWritePlanMock(t *testing.T) *writePlanMock {
+	t.Helper()
+	m := &writePlanMock{}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/admin/tsdb/delete_series":
+			m.deleteCalls.Add(1)
+			if err := r.ParseForm(); err == nil {
+				if s := r.PostForm.Get("start"); s != "" {
+					if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+						m.deleteStart.Store(n)
+					}
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "/api/v2/write":
+			m.writeCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return m
+}
+
+func (m *writePlanMock) close() { m.server.Close() }
+
+func newWritePlanCfg(url string) *Config {
+	tz, _ := time.LoadLocation("Europe/Stockholm")
+	return &Config{
+		VMURL:          url,
+		VMToken:        "tok",
+		InfluxHost:     url,
+		InfluxToken:    "tok",
+		InfluxDatabase: "test",
+		SlotMinutes:    30,
+		PumpKW:         4.0,
+		Timezone:       tz,
+	}
+}
+
+func writePlanFixtureSlots() []time.Time {
+	base := time.Date(2026, 4, 21, 14, 0, 0, 0, time.UTC)
+	return []time.Time{base, base.Add(30 * time.Minute)}
+}
+
+func TestWritePlan_LiveCallsDelete(t *testing.T) {
+	m := newWritePlanMock(t)
+	defer m.close()
+	cfg := newWritePlanCfg(m.server.URL)
+
+	slots := writePlanFixtureSlots()
+	sch := []int{1, 0}
+	prices := []float64{0.5, 0.5}
+	solar := []float64{0, 0}
+	stats := planStats{plannedHours: 0.5, expectedCostSEK: 1.0, slackHours: 0, costPerSlot: []float64{1.0, 0}}
+
+	err := writePlan(cfg, slots, sch, prices, solar, stats, 20.0, true, 6, "optimal", "none",
+		map[string]string{"run": "live"})
+	if err != nil {
+		t.Fatalf("writePlan: %v", err)
+	}
+	if got := m.deleteCalls.Load(); got != 1 {
+		t.Errorf("delete calls = %d, want 1", got)
+	}
+	if got, want := m.deleteStart.Load(), slots[0].Unix(); got != want {
+		t.Errorf("delete start = %d, want %d", got, want)
+	}
+	if got := m.writeCalls.Load(); got != 1 {
+		t.Errorf("write calls = %d, want 1", got)
+	}
+}
+
+func TestWritePlan_NonLiveSkipsDelete(t *testing.T) {
+	for _, runTag := range []string{"backfill", "baseline_night", "baseline_afternoon"} {
+		t.Run(runTag, func(t *testing.T) {
+			m := newWritePlanMock(t)
+			defer m.close()
+			cfg := newWritePlanCfg(m.server.URL)
+
+			slots := writePlanFixtureSlots()
+			sch := []int{1, 0}
+			prices := []float64{0.5, 0.5}
+			solar := []float64{0, 0}
+			stats := planStats{plannedHours: 0.5, expectedCostSEK: 1.0, costPerSlot: []float64{1.0, 0}}
+
+			err := writePlan(cfg, slots, sch, prices, solar, stats, 20.0, true, 6, "optimal", "none",
+				map[string]string{"run": runTag, "anchor_date": "2026-04-20"})
+			if err != nil {
+				t.Fatalf("writePlan: %v", err)
+			}
+			if got := m.deleteCalls.Load(); got != 0 {
+				t.Errorf("delete calls = %d for run=%q, want 0", got, runTag)
+			}
+			if got := m.writeCalls.Load(); got != 1 {
+				t.Errorf("write calls = %d, want 1", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix the 24h plan panel flicker by making each live plan a clean snapshot within its horizon.

**Root cause**: VictoriaMetrics has no dedup. Each container restart runs `writePlan` at startup, writing a full 24h plan under `{run="live"}`. Overlapping slots from different runs accumulate as duplicate (series, timestamp) samples with disagreeing values (where MILP solutions diverged). `last_over_time` non-deterministically picks one, causing 0/1/0/1 flicker in Grafana.

**Fix**: Before writing a live plan, delete previous `{run="live"}` samples within the new plan's horizon. Uses VM's Prom-compatible `/api/v1/admin/tsdb/delete_series` with `start=slots[0].Unix()` — **forward-only**, so historical live-plan records from earlier days are preserved. Backfill and baselines are untouched (gated on `run == "live"`).

## Implementation

- `vm.go`: new `deleteSeries(matcher, start)` helper — POSTs to `/api/v1/admin/tsdb/delete_series`, reuses Bearer+VMToken pattern from `promGet`.
- `planner.go`: call it from `writePlan` inside the live-run branch, after the dry-run guard, before `WritePoints`. Log-and-continue on error.
- `vm_test.go` (new): httptest-based tests covering success, error-status, zero-start, live-calls-delete, and non-live-skips-delete (table-driven across backfill, baseline_night, baseline_afternoon).

## Test plan

- [x] `go vet ./...` — green
- [x] `go test -race -count=1 ./...` — green (5 new test cases + existing)
- [x] `go build ./...` — green
- [ ] Deploy to rpi5, check logs for first `delete_series` call (success or the documented warning)
- [ ] `scripts/vm-query.sh query 'count by (run) (pool_iqpump_plan_on{run="live"}[2h])'` — after next run, expect one copy per slot (was 4)
- [ ] Grafana 24h plan panel reload — expect clean line, no flicker
- [ ] `scripts/vm-shape.sh pool_iqpump_plan` — `run=backfill` and `run=~"baseline_.*"` cardinality unchanged

## Risks

- **vmauth allowlist**: `/api/v1/admin/tsdb/delete_series` may be blocked on the rpi5 vmauth config. First deploy's logs will reveal this (log-and-continue keeps the service running). Mitigation PR would adjust vmauth if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)