### PR TITLE
feat(grafana): add dehumidifier series to humidity panel

### DIFF
--- a/grafana/src/panels/house.ts
+++ b/grafana/src/panels/house.ts
@@ -88,9 +88,9 @@ export function housePanels(): cog.Builder<dashboard.Panel>[] {
     .timeFrom('30m')
     .gridPos({ h: 7, w: 4, x: 20, y: 1 });
 
-  // Ngenic Innegivare - Relativ Luftfuktighet (timeseries)
+  // Luftfuktighet Inomhus (timeseries) - Ngenic indoor sensor + HA dehumidifier
   const humidity = new TimeseriesBuilder()
-    .title('Ngenic Innegivare - Relativ Luftfuktighet')
+    .title('Luftfuktighet Inomhus')
     .datasource(VM_DS)
     .unit('humidity')
     .axisSoftMin(40)
@@ -100,11 +100,17 @@ export function housePanels(): cog.Builder<dashboard.Panel>[] {
     .legend(legendBottom())
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
-    .overrides([overrideDisplayName('humidity_relative_percent', 'Relativ fuktighet')])
     .withTarget(
       vmMetric('A', 'ngenic_node_sensor_measurement_value', 'humidity_relative_percent', {
         where: `"node_type" = 'SENSOR'`,
-      }),
+      }).legendFormat('Hallen'),
+    )
+    .withTarget(
+      vmExpr(
+        'B',
+        'avg(ha_avfuktare_humidity_target_current_humidity_value{}) by (friendly_name)',
+        'Tvättstuga',
+      ),
     )
     .gridPos({ h: 7, w: 8, x: 12, y: 8 });
 


### PR DESCRIPTION
## Summary
- Renames humidity panel to "Luftfuktighet Inomhus" and labels the Ngenic indoor sensor series "Hallen".
- Adds a second target plotting `avg(ha_avfuktare_humidity_target_current_humidity_value{}) by (friendly_name)` labeled "Tvättstuga" so the dehumidifier reading sits alongside the sensor.
- Removes the now-unused `humidity_relative_percent` display-name override since both targets set `legendFormat` explicitly.

## Test plan
- [x] `cd grafana && npm run build` — regenerates `dist/dashboard.json` with both targets (verified expr + legendFormat match).
- [ ] On merge, the Grafana Dashboard workflow uploads and the panel shows both series in Grafana.