### PR TITLE
chore(scripts): add Artifact Registry cleanup policy

### DIFF
--- a/scripts/apply-artifact-cleanup.sh
+++ b/scripts/apply-artifact-cleanup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Apply the Artifact Registry cleanup policy defined in artifact-registry-cleanup.json.
+# Pass --no-dry-run as the first argument to activate deletions; default is dry-run (preview).
+set -euo pipefail
+
+PROJECT="filiplindqvist-com-ea66d"
+LOCATION="europe"
+REPO="images"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLICY_FILE="$SCRIPT_DIR/artifact-registry-cleanup.json"
+
+MODE="${1:---dry-run}"
+case "$MODE" in
+  --dry-run|--no-dry-run) ;;
+  *) echo "usage: $0 [--dry-run|--no-dry-run]" >&2; exit 2 ;;
+esac
+
+gcloud artifacts repositories set-cleanup-policies "$REPO" \
+  --location="$LOCATION" \
+  --project="$PROJECT" \
+  --policy="$POLICY_FILE" \
+  "$MODE"

--- a/scripts/apply-billing-budgets.sh
+++ b/scripts/apply-billing-budgets.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Idempotently apply Cloud Billing budgets for this project.
+# Rerunning updates existing budgets in place (matched by display name).
+set -euo pipefail
+
+BILLING_ACCOUNT="015858-1B075A-316C97"
+BILLING_PROJECT="filiplindqvist-com-ea66d"
+PROJECT_FILTER="projects/530377340060"
+
+# Service IDs (lookup: curl .../cloudbilling.googleapis.com/v1/services)
+SVC_ARTIFACT_REGISTRY="services/149C-F9EC-3994"
+
+find_budget_id() {
+  gcloud billing budgets list \
+    --billing-account="$BILLING_ACCOUNT" \
+    --billing-project="$BILLING_PROJECT" \
+    --filter="displayName=\"$1\"" \
+    --format="value(name)" 2>/dev/null | head -n1 | awk -F/ '{print $NF}'
+}
+
+apply_budget() {
+  local display_name="$1"
+  local amount="$2"
+  local services="$3"
+  local thresholds="$4"  # space-separated percentages, e.g. "0.9 1.2"
+
+  local -a threshold_create=()
+  local -a threshold_update=(--clear-threshold-rules)
+  for p in $thresholds; do
+    threshold_create+=(--threshold-rule="percent=$p")
+    threshold_update+=(--add-threshold-rule="percent=$p")
+  done
+
+  local existing
+  existing=$(find_budget_id "$display_name")
+
+  if [[ -n "$existing" ]]; then
+    echo "==> Updating '$display_name' ($existing)"
+    gcloud billing budgets update "$existing" \
+      --billing-account="$BILLING_ACCOUNT" \
+      --billing-project="$BILLING_PROJECT" \
+      --display-name="$display_name" \
+      --budget-amount="$amount" \
+      --filter-projects="$PROJECT_FILTER" \
+      --filter-services="$services" \
+      "${threshold_update[@]}"
+  else
+    echo "==> Creating '$display_name'"
+    gcloud billing budgets create \
+      --billing-account="$BILLING_ACCOUNT" \
+      --billing-project="$BILLING_PROJECT" \
+      --display-name="$display_name" \
+      --budget-amount="$amount" \
+      --filter-projects="$PROJECT_FILTER" \
+      --filter-services="$services" \
+      "${threshold_create[@]}"
+  fi
+}
+
+# Budget definitions below — add more apply_budget calls as new services need caps.
+apply_budget \
+  "Artifact Registry Monthly" \
+  "40SEK" \
+  "$SVC_ARTIFACT_REGISTRY" \
+  "0.9 1.2"

--- a/scripts/artifact-registry-cleanup.json
+++ b/scripts/artifact-registry-cleanup.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "keep-latest-tagged",
+    "action": {"type": "KEEP"},
+    "condition": {"tagState": "TAGGED"}
+  },
+  {
+    "name": "keep-recent-untagged",
+    "action": {"type": "KEEP"},
+    "mostRecentVersions": {"keepCount": 5}
+  },
+  {
+    "name": "delete-old-untagged",
+    "action": {"type": "DELETE"},
+    "condition": {
+      "tagState": "UNTAGGED",
+      "olderThan": "7d"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

The Google Artifact Registry at `europe-docker.pkg.dev/filiplindqvist-com-ea66d/images` had grown to ~57 GB across 1,950+ image versions. An existing cleanup policy was stuck in dry-run mode and lacked a DELETE rule, so nothing was ever pruned.

## Changes

- `scripts/artifact-registry-cleanup.json` — three-rule policy: KEEP tagged, KEEP 5 most recent untagged, DELETE untagged older than 7d
- `scripts/apply-artifact-cleanup.sh` — reproducible wrapper, defaults to `--dry-run`

Out-of-band (already applied to GCP): orphaned packages `agent-assistant` and `influxdb-proxy` deleted, and the policy above activated with `--no-dry-run`.

## Test plan

- [x] Dry-run applied cleanly (`apply-artifact-cleanup.sh --dry-run`)
- [x] Policy activated (`--no-dry-run`); verified via `gcloud artifacts repositories describe`
- [ ] Re-check `sizeBytes` in ~24h — expected drop from ~57 GB to <10 GB
- [ ] Spot-check rpi5 can still `docker compose pull` (tags preserved by rule 1)