### PR TITLE
feat(backup): emit vm_backup success metric for alerting

### DIFF
--- a/fetcher-core/python/src/backup_vm.py
+++ b/fetcher-core/python/src/backup_vm.py
@@ -4,11 +4,14 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 from google.cloud import storage
+
+from influx import write_influx, Point
 
 INFLUX_HOST = os.environ.get('INFLUX_HOST', '')
 INFLUX_TOKEN = os.environ.get('INFLUX_TOKEN', '')
@@ -77,6 +80,7 @@ def backup_vm():
     gcs_client = _setup_gcs_client()
     timestamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
     filename = f"vm-export-{timestamp}.native.gz"
+    started = time.monotonic()
 
     with tempfile.TemporaryDirectory() as temp_dir:
         archive_path = Path(temp_dir) / filename
@@ -84,7 +88,23 @@ def backup_vm():
             size = _export_to_file(archive_path)
             logging.info("Export completed: %s (%d bytes)", filename, size)
             _upload_to_gcs(archive_path, gcs_client)
+            duration = time.monotonic() - started
             logging.info("VictoriaMetrics backup completed successfully")
+            _emit_success_metric(size_bytes=size, duration_seconds=duration)
         except Exception as e:
             logging.error("VictoriaMetrics backup failed: %s", e)
             raise
+
+
+def _emit_success_metric(size_bytes: int, duration_seconds: float) -> None:
+    try:
+        point = (
+            Point('vm_backup')
+            .tag('destination', 'gcs')
+            .field('last_success_timestamp', float(time.time()))
+            .field('size_bytes', int(size_bytes))
+            .field('duration_seconds', float(duration_seconds))
+        )
+        write_influx([point])
+    except Exception as e:
+        logging.warning("Failed to write vm_backup success metric: %s", e)


### PR DESCRIPTION
## Summary
After a successful VM backup + GCS upload, writes a `vm_backup` measurement to VictoriaMetrics with `last_success_timestamp`, `size_bytes`, and `duration_seconds` fields. This enables a Grafana alert on backup staleness without any new infrastructure.

Reuses the existing `write_influx(points)` helper — same pattern as every other module in `fetcher-core/python/src`. If the metric write fails, it's logged as a warning but doesn't fail the backup.

## Follow-up (not in this PR)
Add a Grafana alert rule: `time() - last_over_time(vm_backup_last_success_timestamp[48h]) > 90000` (25h threshold on a 12h schedule).

## Test plan
- [ ] Deploy and run `backup_vm` manually: `ssh rpi5 'sudo docker exec iot-fetcher python python/src/main.py backup_vm'`
- [ ] Verify metric landed: `scripts/vm-shape.sh vm_backup`
- [ ] Confirm `last_success_timestamp` matches the run time (within a few seconds)