### PR TITLE
fix(webui): collapse multi-series PromQL into one sparkline

### DIFF
--- a/fetcher-core/webui/app/components/LatestValueFullscreen.tsx
+++ b/fetcher-core/webui/app/components/LatestValueFullscreen.tsx
@@ -35,7 +35,7 @@ const LatestValueFullscreen: React.FC<LatestValueFullscreenProps> = ({
     const labelParts = Object.entries(filter).map(([k, v]) => `${k}="${v}"`);
     const selector = labelParts.length > 0 ? `{${labelParts.join(',')}}` : '';
     const inner = expr ?? `${measurement}_${field}${selector}`;
-    return `avg_over_time(${inner}[15m])`;
+    return `avg(avg_over_time(${inner}[15m]))`;
   }, [measurement, field, filter, expr]);
 
   const { initialLoading, error, result } = usePromQLQuery({

--- a/fetcher-core/webui/app/hooks/useHistoryQuery.ts
+++ b/fetcher-core/webui/app/hooks/useHistoryQuery.ts
@@ -16,7 +16,7 @@ function useHistoryQuery({ measurement, field, filter = {}, expr, sparkline }: U
   const selector = labelParts.length > 0 ? `{${labelParts.join(',')}}` : '';
   const inner = expr ?? `${measurement}_${field}${selector}`;
 
-  const query = enabled ? `avg_over_time(${inner}[5m])` : 'up';
+  const query = enabled ? `avg(avg_over_time(${inner}[5m]))` : 'up';
 
   const { start, end, step } = useMemo(() => {
     if (!enabled) return { start: new Date().toISOString(), end: new Date().toISOString(), step: '5m' };

--- a/fetcher-core/webui/app/lib/values.ts
+++ b/fetcher-core/webui/app/lib/values.ts
@@ -21,7 +21,7 @@ export const values: Config = [
         { measurement: 'ha_volvo_xc40_charging_power', field: 'value', title: '🔌 XC40 Laddning', unit: 'W', decimals: 0, reload: 60000, sparkline: '24h', sparklineMin: 0 },
     ],
     [
-        { measurement: 'sigenergy_pv_power', field: 'power_kw', title: '☀️ Solceller Produktion', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: 0, sparklineMax: 3 },
+        { measurement: 'sigenergy_pv_power', field: 'power_kw', filter: { string: 'total' }, title: '☀️ Solceller Produktion', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: 0, sparklineMax: 3 },
         { measurement: 'sigenergy_grid_power', field: 'net_power_kw', title: '⚡️ Nät Inköp', unit: 'kW', decimals: 1, reload: 10000, sparkline: '24h', sparklineMin: -5, sparklineMax: 10 },
         { measurement: 'sigenergy_home', field: 'load_kw',
          expr: 'clamp_min(sigenergy_pv_power_power_kw{string="total"} + on(host) sigenergy_grid_power_net_power_kw + on(host) sigenergy_battery_power_from_battery_kw, 0)',


### PR DESCRIPTION
## Summary
- Sparklines and the 7-day modal were scattered/zigzagging because `usePromQLQuery.ts` concatenates multi-series range responses, and ECharts (`smooth: true`) then drew connecting lines across series boundaries — VM currently has a stale `host=127.0.0.1` alongside the real sigenergy host, causing the spurious diagonal.
- Wrapped the range queries in `useHistoryQuery.ts` and `LatestValueFullscreen.tsx` with `avg(...)` so each tile resolves to exactly one series (verified via `query_range` for all six affected expressions).
- Added the missing `string="total"` filter on Solceller Produktion so the `avg()` doesn't blend per-MPPT `string_1`/`string_4` into the aggregate `total`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] All six affected PromQL queries return exactly 1 series over 24h/7d
- [ ] Build image, deploy to rpi5, confirm each tile's sparkline is one continuous line and the 7-day modal no longer shows the diagonal overlay