### PR TITLE
fix(grafana): stepAfter + 15m min interval on pool pump plan panel

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -92,6 +92,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
   const pumpPlan = new TimeseriesBuilder()
     .title('Poolpump plan (24h)')
     .datasource(VM_DS)
+    .interval('15m')
+    .lineInterpolation('stepAfter' as any)
     .colorScheme(paletteColor())
     .thresholds(greenThreshold())
     .legend(legendBottom())


### PR DESCRIPTION
## Summary
- `Poolpump plan (24h)` rendered as slanted spikes because Grafana defaulted to linear interpolation across 15-min samples — `stepAfter` draws the 0/1 `Pump på` signal as a proper staircase, matching the convention already used for spot-price panels in `energy.ts`.
- Panel-level `interval('15m')` clamps `$__interval` so each query step maps to exactly one planner write; targets continue using the built-in variable rather than hardcoding `[15m]`.
- Writer-side duplicate samples (the other half of the spikiness) land in a follow-up PR; this change is pure display config, zero risk.

## Test plan
- [x] `npm run build` in `grafana/` emits `interval: "15m"` and `lineInterpolation: "stepAfter"` on the target panel only; `Poolpump plan (30 dagar backfill)` unchanged.
- [ ] `npm run generate` to upload to Grafana, then open the panel and confirm staircase rendering + query-inspector step of 900s.