### PR TITLE
feat(vm): enable dedup with 10s minScrapeInterval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - -storageDataPath=/victoria-metrics-data
       - -retentionPeriod=3y
       - -httpListenAddr=:8181
+      - -dedup.minScrapeInterval=10s
 
   database-auth:
     image: victoriametrics/vmauth:latest


### PR DESCRIPTION
Adds `-dedup.minScrapeInterval=10s` to the VictoriaMetrics container. This deduplicates samples within a 10-second window at compaction time, matching the finest scrape precision in use. Existing data will be deduped gradually as partitions compact; the current month's partition can be force-merged via `/internal/force_merge` if needed.