### PR TITLE
feat(pool-pump-planner): plan_date-tagged, idempotent tomorrow-only plan

### DIFF
--- a/pool-pump-planner/main.go
+++ b/pool-pump-planner/main.go
@@ -33,12 +33,20 @@ func main() {
 		return
 	}
 
-	// Run once on startup (mirroring python schedule.run_all), then daily at POOL_PLAN_TIME.
-	runPlanner(cfg)
-
 	hh, mm, err := parseHHMM(cfg.PlanTime)
 	if err != nil {
 		log.Fatalf("invalid POOL_PLAN_TIME %q: %v", cfg.PlanTime, err)
+	}
+
+	// Gate the startup run on "tomorrow's Nord Pool prices are published"
+	// (local hour >= POOL_PLAN_TIME). Before that, today's plan should
+	// already exist from yesterday's 14:05 run. This prevents every
+	// wud-triggered container restart from rewriting tomorrow's plan with
+	// a stale mid-day snapshot of inputs.
+	if now := time.Now().In(cfg.Timezone); now.Hour() >= hh {
+		runPlanner(cfg)
+	} else {
+		log.Printf("[planner] skipping startup run (current hour %d < plan hour %d; today's plan should already exist)", now.Hour(), hh)
 	}
 
 	for {

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -41,10 +41,20 @@ type planInputs struct {
 
 func nan() float64 { return math.NaN() }
 
-// runPlanner is the top-level entry. Any error is logged so the caller can
-// keep running on a schedule without crashing.
+// runPlanner is the top-level entry. Always plans the next local calendar
+// day (tomorrow), tags every point with plan_date=<tomorrow YYYY-MM-DD>,
+// and deletes any prior live-plan for that date before writing so repeat
+// runs are idempotent. Any error is logged so the caller can keep running
+// on a schedule without crashing.
 func runPlanner(cfg *Config) {
-	if _, _, err := plan(cfg, time.Now().UTC(), map[string]string{"run": "live"}); err != nil {
+	tomorrow := time.Now().In(cfg.Timezone).AddDate(0, 0, 1)
+	planStart := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, cfg.Timezone)
+	planDate := planStart.Format("2006-01-02")
+
+	cfg.deletePlanForDate(planDate)
+
+	tags := map[string]string{"run": "live", "plan_date": planDate}
+	if _, _, err := plan(cfg, planStart.UTC(), tags); err != nil {
 		log.Printf("[planner] run failed: %v", err)
 	}
 }
@@ -323,8 +333,11 @@ func solve(cfg *Config, slots []time.Time, prices, solar []float64, targetHours 
 	return result.schedule, stats, nil
 }
 
-func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
-	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) error {
+// buildPlanPoints assembles the line-protocol points for one plan run:
+// 96 slot points plus a single summary point. Pure — no IO — so tests can
+// assert the tag/field shape directly.
+func buildPlanPoints(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) []*Point {
 	applyTags := func(p *Point) *Point {
 		for k, v := range extraTags {
 			p.Tag(k, v)
@@ -340,11 +353,12 @@ func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float6
 			Field("on", sch[t]).
 			Field("cost_sek", stats.costPerSlot[t]).
 			At(slot)
-		priceField := 0.0
+		// Missing Nord Pool price → omit the field so the panel renders a
+		// gap. Writing 0.0 would conflate "we have no data" with "price was
+		// really zero", which is never a legitimate SE4 value.
 		if len(prices) > t && !math.IsNaN(prices[t]) {
-			priceField = prices[t]
+			p.Field("price_sek_per_kwh", prices[t])
 		}
-		p.Field("price_sek_per_kwh", priceField)
 		solarField := 0.0
 		if len(solar) > t {
 			solarField = solar[t]
@@ -378,6 +392,17 @@ func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float6
 		Field("water_temp_c", waterC).
 		At(slots[0])
 	points = append(points, summary)
+	return points
+}
+
+func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) error {
+	points := buildPlanPoints(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, mode, missing, extraTags)
+
+	missingTag := missing
+	if missingTag == "" {
+		missingTag = "none"
+	}
 
 	if cfg.DryRun {
 		printSchedule(cfg, slots, sch, prices, solar, stats.costPerSlot)

--- a/pool-pump-planner/planner_test.go
+++ b/pool-pump-planner/planner_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math"
 	"testing"
+	"time"
 )
 
 func TestSlotCost(t *testing.T) {
@@ -78,5 +79,54 @@ func TestSlotCost(t *testing.T) {
 					tc.slotEnergy, tc.price, tc.solar, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildPlanPointsOmitsNaNPrice(t *testing.T) {
+	cfg := &Config{SlotMinutes: 15}
+	slots := []time.Time{
+		time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 23, 0, 15, 0, 0, time.UTC),
+		time.Date(2026, 4, 23, 0, 30, 0, 0, time.UTC),
+	}
+	sch := []int{0, 1, 0}
+	prices := []float64{0.42, math.NaN(), -0.001}
+	solar := []float64{0, 0, 0}
+	stats := planStats{costPerSlot: []float64{0, 0, 0}}
+	tags := map[string]string{"run": "live", "plan_date": "2026-04-23"}
+
+	points := buildPlanPoints(cfg, slots, sch, prices, solar, stats, 0, false, 6, "optimal", "", tags)
+
+	if len(points) != len(slots)+1 {
+		t.Fatalf("expected %d points (slots + summary), got %d", len(slots)+1, len(points))
+	}
+
+	checkPrice := func(i int, wantField bool, wantVal float64) {
+		p := points[i]
+		got, ok := p.Fields["price_sek_per_kwh"]
+		if wantField {
+			if !ok {
+				t.Errorf("slot %d: expected price_sek_per_kwh field, missing", i)
+				return
+			}
+			if v, _ := got.(float64); v != wantVal {
+				t.Errorf("slot %d: price_sek_per_kwh = %v, want %v", i, got, wantVal)
+			}
+		} else if ok {
+			t.Errorf("slot %d: expected no price_sek_per_kwh field (NaN input), got %v", i, got)
+		}
+	}
+	checkPrice(0, true, 0.42)
+	checkPrice(1, false, 0)
+	checkPrice(2, true, -0.001) // negative prices are legitimate SE4 values
+
+	// plan_date + run tags must propagate to every slot point and the summary.
+	for i, p := range points {
+		if p.Tags["plan_date"] != "2026-04-23" {
+			t.Errorf("point %d: plan_date tag = %q, want %q", i, p.Tags["plan_date"], "2026-04-23")
+		}
+		if p.Tags["run"] != "live" {
+			t.Errorf("point %d: run tag = %q, want %q", i, p.Tags["run"], "live")
+		}
 	}
 }

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -220,3 +220,43 @@ func (c *Config) fetchWaterTempAt(at time.Time) (float64, bool) {
 func (c *Config) fetchWaterTemp() (float64, bool) {
 	return c.fetchWaterTempAt(time.Time{})
 }
+
+// deletePlanForDate removes any existing live-plan points tagged with the
+// given plan_date, making the planner idempotent on re-run. Best-effort:
+// logs and returns without error so a blocked or unavailable admin endpoint
+// doesn't prevent the fresh write. DryRun short-circuits to no-op.
+func (c *Config) deletePlanForDate(planDate string) {
+	if c.DryRun {
+		log.Printf("[planner] DRY RUN: skipping delete for plan_date=%s", planDate)
+		return
+	}
+	base := c.vmBaseURL()
+	if base == "" {
+		log.Printf("[planner] VM URL not configured, skipping delete for plan_date=%s", planDate)
+		return
+	}
+	q := url.Values{}
+	q.Set("match[]", fmt.Sprintf(`{__name__=~"pool_iqpump_plan.*",run="live",plan_date="%s"}`, planDate))
+	u := base + "/api/v1/admin/tsdb/delete_series?" + q.Encode()
+	req, err := http.NewRequest("POST", u, nil)
+	if err != nil {
+		log.Printf("[planner] plan_date delete request build failed: %v, continuing", err)
+		return
+	}
+	if c.VMToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.VMToken)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("[planner] plan_date delete failed: %v, continuing", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		log.Printf("[planner] plan_date delete HTTP %d: %s, continuing", resp.StatusCode, string(body))
+		return
+	}
+	log.Printf("[planner] deleted prior plan for plan_date=%s", planDate)
+}


### PR DESCRIPTION
## Summary
- Each live planner run now produces **one plan per local calendar day** (tomorrow), tagged `plan_date=<YYYY-MM-DD>`. Before writing, any prior plan for the same `plan_date` is wiped via `/api/v1/admin/tsdb/delete_series`, so repeat runs (wud-triggered restarts, manual `-once`) are idempotent instead of stacking overlapping 24h-forward schedules.
- Startup run is gated on `local hour >= POOL_PLAN_TIME`. Before 14:00 it skips — today's plan should already exist from yesterday's 14:05 run, and tomorrow's Nord Pool prices aren't published yet.
- NaN Nord Pool prices now **omit** the `price_sek_per_kwh` field instead of being substituted with `0.0`. Negative and near-zero SE4 prices pass through unchanged; only genuinely missing hours produce gaps. This eliminates the false Spotpris drops on the panel.
- Delete call is best-effort — a blocked admin endpoint logs a warning but doesn't halt the write.

## Test plan
- [x] `go build ./... && go test ./...` in `pool-pump-planner/`. New `TestBuildPlanPointsOmitsNaNPrice` covers NaN→omit, negative-value passthrough, and `plan_date`/`run` tag propagation.
- [x] `TZ=Europe/Stockholm go run . -dry-run` confirms the plan window anchors at tomorrow's local midnight and spans 00:00 → 23:45 local.
- [ ] Post-deploy on rpi5: verify logs show either `skipping startup run (...)` or `deleted prior plan for plan_date=... / plan written ...`; VM `/api/v1/export` returns one sample per slot for tomorrow's `plan_date`.

## Post-merge cleanup (one-time)

After the new image is deployed on rpi5 **and** the first scheduled/manual run has written fresh `plan_date`-tagged points, wipe the legacy untagged live data for a clean slate. The selector `plan_date=""` matches only series where the label is missing, so fresh tagged writes are preserved.

```sh
HOST=$(grep '^INFLUX_HOST=' fetcher-core/python/.env.local | cut -d= -f2-)
TOKEN=$(grep '^INFLUX_TOKEN=' fetcher-core/python/.env.local | cut -d= -f2-)

curl -sS -H "Authorization: Bearer $TOKEN" -X POST \
  --data-urlencode 'match[]={__name__=~"pool_iqpump_plan.*",run="live",plan_date=""}' \
  "$HOST/api/v1/admin/tsdb/delete_series"
```

Verify afterwards:

```sh
curl -sS -H "Authorization: Bearer $TOKEN" \
  --data-urlencode 'match[]=pool_iqpump_plan_on{run="live"}' \
  "$HOST/api/v1/series" | jq '.data'
```

Expect every remaining series to carry a `plan_date` label. Any series without one = cleanup missed it.