### PR TITLE
feat(grafana): add System row with discharge control and VM backup panels

### DIFF
--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -9,6 +9,7 @@ import { eufyPanels } from './panels/eufy.ts';
 import { lightingPanels } from './panels/lighting.ts';
 import { navimowPanels } from './panels/navimow.ts';
 import { volvoPanels } from './panels/volvo.ts';
+import { systemPanels } from './panels/system.ts';
 
 function buildDashboard() {
   const builder = new DashboardBuilder('Irisgatan')
@@ -80,6 +81,12 @@ function buildDashboard() {
   // Tapo row
   builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 103 }));
   for (const panel of tapoPanels()) {
+    builder.withPanel(panel);
+  }
+
+  // System row (meta metrics)
+  builder.withRow(new RowBuilder('System').gridPos({ h: 1, w: 24, x: 0, y: 111 }));
+  for (const panel of systemPanels()) {
     builder.withPanel(panel);
   }
 

--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -1,0 +1,58 @@
+import { PanelBuilder as TimeseriesBuilder } from '@grafana/grafana-foundation-sdk/timeseries';
+import { PanelBuilder as StatBuilder } from '@grafana/grafana-foundation-sdk/stat';
+import type * as cog from '@grafana/grafana-foundation-sdk/cog';
+import type * as dashboard from '@grafana/grafana-foundation-sdk/dashboard';
+import { VM_DS, vmExpr } from '../datasource.ts';
+import {
+  thresholds, paletteColor,
+  legendBottom, tooltipMulti,
+  SPAN_NULLS_MS,
+} from '../helpers.ts';
+
+export function systemPanels(): cog.Builder<dashboard.Panel>[] {
+  // 🔒 Urladdningskontroll (timeseries, stepAfter)
+  const dischargeControl = new TimeseriesBuilder()
+    .title('🔒 Urladdningskontroll')
+    .datasource(VM_DS)
+    .interval('1m')
+    .colorScheme(paletteColor())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .lineInterpolation('stepAfter' as any)
+    .min(0)
+    .insertNulls(SPAN_NULLS_MS)
+    .overrides([
+      {
+        matcher: { id: 'byName', options: 'limit_w' },
+        properties: [
+          { id: 'custom.axisPlacement', value: 'right' },
+          { id: 'unit', value: 'watt' },
+          { id: 'displayName', value: 'Gräns (W)' },
+        ],
+      },
+    ])
+    .withTarget(
+      vmExpr('Active', 'last_over_time(sigenergy_discharge_control_active[$__interval])').legendFormat('{{reason}}'),
+    )
+    .withTarget(
+      vmExpr('Limit', 'last_over_time(sigenergy_discharge_control_limit_w[$__interval])', 'limit_w'),
+    )
+    .gridPos({ h: 8, w: 16, x: 0, y: 112 });
+
+  // 💾 Senaste VM-backup (stat, age in seconds)
+  const vmBackup = new StatBuilder()
+    .title('💾 Senaste VM-backup')
+    .datasource(VM_DS)
+    .unit('dtdurations')
+    .thresholds(thresholds([
+      { color: 'green', value: null },
+      { color: '#EAB839', value: 90000 },
+      { color: 'red', value: 172800 },
+    ]))
+    .withTarget(
+      vmExpr('A', 'time() - last_over_time(vm_backup_last_success_timestamp[$__interval])'),
+    )
+    .gridPos({ h: 8, w: 8, x: 16, y: 112 });
+
+  return [dischargeControl, vmBackup];
+}


### PR DESCRIPTION
Adds a new 'System' row at the bottom of the Irisgatan dashboard with two meta-metric panels: a stepAfter timeseries for `sigenergy_discharge_control` (shows active/limit_w by reason tag) and a stat panel for `vm_backup` (time since last successful GCS backup, yellow at 25h, red at 48h). Panels live in a new `grafana/src/panels/system.ts` file.