### PR TITLE
fix(pool-plan): unblock optimal mode — 12h water temp lookback + elpris/planner timing

### DIFF
--- a/fetcher-core/python/src/main.py
+++ b/fetcher-core/python/src/main.py
@@ -65,7 +65,11 @@ def main():
     schedule.every(5).minutes.do(with_timeout(eufy))
     schedule.every(1).minutes.do(with_timeout(sonos))
 
-    schedule.every(6).hours.at(':05').do(with_timeout(elpris))
+    # Primary: run right before the pool-pump-planner fires at 14:15 local,
+    # so day-ahead prices are fresh. Backup every 6h in case the primary is
+    # missed (container down, job slip, etc.).
+    schedule.every().day.at('14:03').do(with_timeout(elpris))
+    schedule.every(6).hours.do(with_timeout(elpris))
     schedule.every(1).hours.at(':05').do(with_timeout(airquality))
     # schedule.every(1).hours.at(':10').do(with_timeout(balboa_control))  # Disabled SPA module
     schedule.every(3).hours.at(':15').do(with_timeout(eufy_snapshot))

--- a/pool-pump-planner/config.go
+++ b/pool-pump-planner/config.go
@@ -112,7 +112,7 @@ func loadConfig() *Config {
 
 		PriceArea:   getenv("POOL_PRICE_AREA", "SE4"),
 		SlotMinutes: getenvInt("POOL_SLOT_MINUTES", 15),
-		PlanTime:    getenv("POOL_PLAN_TIME", "14:05"),
+		PlanTime:    getenv("POOL_PLAN_TIME", "14:15"),
 	}
 
 	tzName := getenv("POOL_TIMEZONE", "Europe/Stockholm")

--- a/pool-pump-planner/vm.go
+++ b/pool-pump-planner/vm.go
@@ -205,8 +205,12 @@ func (c *Config) fetchHourlyPrices(slots []time.Time) []float64 {
 	return out
 }
 
+// fetchWaterTempAt looks back up to 12h for the most recent pool temperature
+// reading. The sensor publishes only on change (often hourly), so VM's default
+// ~5m lookback regularly misses a valid-enough reading and drops the planner
+// into fallback mode.
 func (c *Config) fetchWaterTempAt(at time.Time) (float64, bool) {
-	result, err := c.queryPromInstantAt("pool_temperature_value", at, "")
+	result, err := c.queryPromInstantAt("pool_temperature_value", at, "12h")
 	if err != nil {
 		log.Printf("[planner] water temp query failed: %v", err)
 		return 0, false


### PR DESCRIPTION
## Summary
Yesterday's 12:05 UTC run fell back to a static schedule with `missing=prices,water_temp`. Three small fixes so the planner lands in optimal mode again:

1. **Water temp lookback → 12h** (`pool-pump-planner/vm.go`)
   The sensor only publishes on change (≈ hourly), so VM's default ~5m lookback routinely misses a fresh-enough reading. Prices remain required; only water_temp tolerates the wider staleness.
2. **Elpris pinned to 14:03 local + 6h backup** (`fetcher-core/python/src/main.py`)
   Previously `every(6).hours.at(':05')` could align with the planner's 14:05 firing and race it on the one time of day when Nord Pool publishes new day-ahead prices. Pin a primary daily run at 14:03, keep 6h as a safety net.
3. **Planner default shifted to 14:15** (`pool-pump-planner/config.go`)
   Gives elpris a comfortable window to finish writing prices to VM before the planner queries.

## Test plan
- [x] `go build ./... && go test ./...` in `pool-pump-planner/` passes
- [x] Verified live: `lookback_delta=12h` returns current 7.3 °C reading
- [ ] After deploy: confirm next run logs `mode=optimal` with `water_temp=<value>` and full 96/96 price coverage