### PR TITLE
fix: correct XC40 charging power unit (kW → W)

### DIFF
--- a/grafana/src/panels/volvo.ts
+++ b/grafana/src/panels/volvo.ts
@@ -39,7 +39,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
   const chargingTs = new TimeseriesBuilder()
     .title('⚡ XC40 Laddeffekt')
     .datasource(VM_DS)
-    .unit('kwatt')
+    .unit('watt')
     .axisSoftMin(0)
     .colorScheme(paletteColor())
     .thresholds(greenThreshold())


### PR DESCRIPTION
## Summary

- The `⚡ XC40 Laddeffekt` Grafana panel had unit set to `kwatt` (kilowatts), but the metric `ha_volvo_xc40_charging_power_value` reports in watts
- This caused values to display 1000× too high — e.g. a 1.5 kW charge session showed as 1.5 MW
- Fix: change `.unit('kwatt')` → `.unit('watt')` in `grafana/src/panels/volvo.ts` and regenerate dashboard JSON

## Test plan

- [ ] Deploy updated dashboard to Grafana (`npm run generate` in `grafana/`)
- [ ] Verify XC40 Laddeffekt panel shows values in kW range (e.g. ~11 kW for AC charging) instead of MW

https://claude.ai/code/session_018UwzaRB1PCAbEXAmCSeNro

---
_Generated by [Claude Code](https://claude.ai/code/session_018UwzaRB1PCAbEXAmCSeNro)_