### PR TITLE
fix(grafana): separate Spabadet row and fix Energi panel placement

### DIFF
--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -38,11 +38,12 @@ function buildDashboard() {
     builder.withPanel(panel);
   }
 
-  // Belysning row
-  builder.withRow(new RowBuilder('Belysning').gridPos({ h: 1, w: 24, x: 0, y: 15 }));
+  // Belysning row (collapsed)
+  const belysningRow = new RowBuilder('Belysning').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 15 });
   for (const panel of lightingPanels()) {
-    builder.withPanel(panel);
+    belysningRow.withPanel(panel);
   }
+  builder.withRow(belysningRow);
 
   // Poolen row
   builder.withRow(new RowBuilder('Poolen').gridPos({ h: 1, w: 24, x: 0, y: 23 }));

--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -44,48 +44,51 @@ function buildDashboard() {
     builder.withPanel(panel);
   }
 
-  // Poolen row (includes pool + spa panels)
+  // Poolen row
   builder.withRow(new RowBuilder('Poolen'));
   for (const panel of poolPanels()) {
     builder.withPanel(panel);
   }
+
+  // Spabadet row
+  builder.withRow(new RowBuilder('Spabadet').gridPos({ h: 1, w: 24, x: 0, y: 60 }));
   for (const panel of spaPanels()) {
     builder.withPanel(panel);
   }
 
   // Energi row
-  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 60 }));
+  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 69 }));
   for (const panel of energyPanels()) {
     builder.withPanel(panel);
   }
 
   // Volvo XC40 row
-  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 84 }));
+  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 100 }));
   for (const panel of volvoPanels()) {
     builder.withPanel(panel);
   }
 
   // Navimow row
-  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 93 }));
+  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 109 }));
   for (const panel of navimowPanels()) {
     builder.withPanel(panel);
   }
 
   // Eufy Cameras row (collapsed)
-  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 102 });
+  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 118 });
   for (const panel of eufyPanels()) {
     eufyRow.withPanel(panel);
   }
   builder.withRow(eufyRow);
 
   // Tapo row
-  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 103 }));
+  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 119 }));
   for (const panel of tapoPanels()) {
     builder.withPanel(panel);
   }
 
   // System row (meta metrics)
-  builder.withRow(new RowBuilder('System').gridPos({ h: 1, w: 24, x: 0, y: 111 }));
+  builder.withRow(new RowBuilder('System').gridPos({ h: 1, w: 24, x: 0, y: 127 }));
   for (const panel of systemPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -39,13 +39,13 @@ function buildDashboard() {
   }
 
   // Belysning row
-  builder.withRow(new RowBuilder('Belysning'));
+  builder.withRow(new RowBuilder('Belysning').gridPos({ h: 1, w: 24, x: 0, y: 15 }));
   for (const panel of lightingPanels()) {
     builder.withPanel(panel);
   }
 
   // Poolen row
-  builder.withRow(new RowBuilder('Poolen'));
+  builder.withRow(new RowBuilder('Poolen').gridPos({ h: 1, w: 24, x: 0, y: 23 }));
   for (const panel of poolPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/panels/energy.ts
+++ b/grafana/src/panels/energy.ts
@@ -31,7 +31,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipSingle())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'sigenergy_battery', 'soc_percent'))
-    .gridPos({ h: 8, w: 9, x: 0, y: 46 });
+    .gridPos({ h: 8, w: 9, x: 0, y: 70 });
 
   // ☀️ Solceller effekt (stat)
   const solar = new StatBuilder()
@@ -46,7 +46,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
         where: `"string" = 'total'`,
       }),
     )
-    .gridPos({ h: 8, w: 4, x: 9, y: 46 });
+    .gridPos({ h: 8, w: 4, x: 9, y: 70 });
 
   // 🪫 Urladdning (stat)
   const discharge = new StatBuilder()
@@ -57,7 +57,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .max(10)
     .thresholds(greenThreshold())
     .withTarget(vmMetric('A', 'sigenergy_battery', 'power_to_battery_kw'))
-    .gridPos({ h: 8, w: 4, x: 13, y: 46 });
+    .gridPos({ h: 8, w: 4, x: 13, y: 70 });
 
   // ⚡️ Energiförbrukning - simple (timeseries, mean+max)
   const energySimple = new TimeseriesBuilder()
@@ -72,7 +72,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('DjUv', 'tibber', 'power'))
     .withTarget(vmMetric('B', 'tibber', 'power', { agg: 'MAX' }))
-    .gridPos({ h: 8, w: 7, x: 17, y: 46 });
+    .gridPos({ h: 8, w: 7, x: 17, y: 70 });
 
   // ⚡️ Energiförbrukning - detailed (timeseries, 4 queries)
   const energyDetailed = new TimeseriesBuilder()
@@ -124,7 +124,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
         'power_kw',
       ),
     )
-    .gridPos({ h: 8, w: 9, x: 0, y: 54 });
+    .gridPos({ h: 8, w: 9, x: 0, y: 78 });
 
   // ⚡️ Energiförbrukning (stat)
   const energyStat = new StatBuilder()
@@ -133,7 +133,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .unit('kwatth')
     .thresholds(energyThresholds())
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption', { agg: 'LAST_VALUE' }))
-    .gridPos({ h: 8, w: 3, x: 9, y: 54 });
+    .gridPos({ h: 8, w: 3, x: 9, y: 78 });
 
   // ⚡️ Energiförbrukning per fas (timeseries)
   const energyPhases = new TimeseriesBuilder()
@@ -153,7 +153,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'avg_over_time(tibber_powerL1[$__interval])', 'powerL1'))
     .withTarget(vmExpr('B', 'avg_over_time(tibber_powerL2[$__interval])', 'powerL2'))
     .withTarget(vmExpr('C', 'avg_over_time(tibber_powerL3[$__interval])', 'powerL3'))
-    .gridPos({ h: 8, w: 12, x: 12, y: 54 });
+    .gridPos({ h: 8, w: 12, x: 12, y: 78 });
 
   // Dygnskostnad 30d (bar chart)
   const dailyCost30d = new TimeseriesBuilder()
@@ -177,7 +177,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedCost', { agg: 'MAX' }))
     .timeFrom('30d/d')
-    .gridPos({ h: 6, w: 7, x: 0, y: 62 });
+    .gridPos({ h: 6, w: 7, x: 0, y: 86 });
 
   // Dygnsförbrukning 30d (bar chart)
   const dailyConsumption30d = new TimeseriesBuilder()
@@ -200,7 +200,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption', { agg: 'MAX' }))
     .timeFrom('30d/d')
-    .gridPos({ h: 6, w: 9, x: 7, y: 62 });
+    .gridPos({ h: 6, w: 9, x: 7, y: 86 });
 
   // Veckopris (timeseries, stepAfter, 7d)
   const weeklyPrice = new TimeseriesBuilder()
@@ -229,7 +229,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
       }),
     )
     .timeFrom('7d/d')
-    .gridPos({ h: 6, w: 8, x: 16, y: 62 });
+    .gridPos({ h: 6, w: 8, x: 16, y: 86 });
 
   // Dygnskostnad 1d (timeseries)
   const dailyCost1d = new TimeseriesBuilder()
@@ -250,7 +250,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedCost'))
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 7, x: 0, y: 68 });
+    .gridPos({ h: 8, w: 7, x: 0, y: 92 });
 
   // Dygnsförbrukning 1d (timeseries)
   const dailyConsumption1d = new TimeseriesBuilder()
@@ -271,7 +271,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption'))
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 9, x: 7, y: 68 });
+    .gridPos({ h: 8, w: 9, x: 7, y: 92 });
 
   // Dygnspris (timeseries, stepAfter, 1d)
   const dailyPrice = new TimeseriesBuilder()
@@ -299,7 +299,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
       }),
     )
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 8, x: 16, y: 68 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 92 });
 
   return [
     battery, solar, discharge, energySimple,

--- a/grafana/src/panels/house.ts
+++ b/grafana/src/panels/house.ts
@@ -133,52 +133,6 @@ export function housePanels(): cog.Builder<dashboard.Panel>[] {
     .timeFrom('7d/d')
     .gridPos({ h: 7, w: 4, x: 20, y: 8 });
 
-  // Ngenic Batteri (timeseries, 30d) - aggregated by node type
-  const sensorBattery = new TimeseriesBuilder()
-    .title('Ngenic Batteri')
-    .datasource(VM_DS)
-    .unit('percent')
-    .min(0)
-    .max(100)
-    .interval('1h')
-    .colorScheme(paletteColor())
-    .thresholds(greenThreshold())
-    .legend(legendBottom())
-    .tooltip(tooltipSingle())
-    .insertNulls(SPAN_NULLS_MS)
-    .overrides([
-      overrideDisplayName('SENSOR', 'Innegivare'),
-      overrideDisplayName('CONTROLLER', 'Styrenhet'),
-    ])
-    .withTarget(
-      vmExpr('A', 'avg by (node_type) (avg_over_time(ngenic_node_battery_value[$__interval]))', '{{node_type}}'),
-    )
-    .timeFrom('30d/d')
-    .gridPos({ h: 7, w: 12, x: 0, y: 15 });
-
-  // Ngenic Radiosignal (timeseries, 30d) - aggregated by node type
-  const sensorSignal = new TimeseriesBuilder()
-    .title('Ngenic Radiosignal')
-    .datasource(VM_DS)
-    .unit('percent')
-    .min(0)
-    .max(100)
-    .interval('1h')
-    .colorScheme(paletteColor())
-    .thresholds(greenThreshold())
-    .legend(legendBottom())
-    .tooltip(tooltipSingle())
-    .insertNulls(SPAN_NULLS_MS)
-    .overrides([
-      overrideDisplayName('SENSOR', 'Innegivare'),
-      overrideDisplayName('CONTROLLER', 'Styrenhet'),
-    ])
-    .withTarget(
-      vmExpr('A', 'avg by (node_type) (avg_over_time(ngenic_node_radio_signal_value[$__interval]))', '{{node_type}}'),
-    )
-    .timeFrom('30d/d')
-    .gridPos({ h: 7, w: 12, x: 12, y: 15 });
-
   // Sovrum (timeseries) - bedroom climate temperature
   const bedroomTemp = new TimeseriesBuilder()
     .title('Sovrum')
@@ -209,7 +163,7 @@ export function housePanels(): cog.Builder<dashboard.Panel>[] {
     .timeFrom('30m')
     .gridPos({ h: 7, w: 4, x: 8, y: 8 });
 
-  return [indoorTemp, indoorStat, outdoorTemp, outdoorStat, humidity, aqi, bedroomTemp, bedroomStat, sensorBattery, sensorSignal];
+  return [indoorTemp, indoorStat, outdoorTemp, outdoorStat, humidity, aqi, bedroomTemp, bedroomStat];
 }
 
 export function tapoPanels(): cog.Builder<dashboard.Panel>[] {
@@ -239,7 +193,7 @@ export function tapoPanels(): cog.Builder<dashboard.Panel>[] {
       ),
     )
     .timeFrom('7d/d')
-    .gridPos({ h: 7, w: 12, x: 0, y: 104 });
+    .gridPos({ h: 7, w: 12, x: 0, y: 120 });
 
   return [tapoOnline];
 }

--- a/grafana/src/panels/lighting.ts
+++ b/grafana/src/panels/lighting.ts
@@ -32,7 +32,7 @@ export function lightingPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('B', 'last_over_time(pool_area_lights_value[$__interval])', 'pool_area_lights'))
     .withTarget(vmExpr('C', 'last_over_time(terrace_lightning_value[$__interval])', 'terrace_lightning'))
     .withTarget(vmExpr('D', 'last_over_time(facade_lighting_value[$__interval])', 'facade_lighting'))
-    .gridPos({ h: 7, w: 12, x: 0, y: 23 });
+    .gridPos({ h: 7, w: 12, x: 0, y: 16 });
 
   // Belysning effekt (power)
   const powerTs = new TimeseriesBuilder()
@@ -55,7 +55,7 @@ export function lightingPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('B', 'avg_over_time(pool_area_lights_power_value[$__interval])', 'pool_area_lights_power'))
     .withTarget(vmExpr('C', 'avg_over_time(terrace_lightning_power_value[$__interval])', 'terrace_lightning_power'))
     .withTarget(vmExpr('D', 'avg_over_time(facade_lighting_power_value[$__interval])', 'facade_lighting_power'))
-    .gridPos({ h: 7, w: 12, x: 12, y: 23 });
+    .gridPos({ h: 7, w: 12, x: 12, y: 16 });
 
   return [statusTs, powerTs];
 }

--- a/grafana/src/panels/navimow.ts
+++ b/grafana/src/panels/navimow.ts
@@ -26,7 +26,7 @@ export function navimowPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('Navimow i206 AWD Battery', 'Navimow i206 AWD Battery', 'green'),
     ])
     .withTarget(vmExpr('A', 'last_over_time(ha_navimow_i206_awd_battery_value[$__interval])', '{{friendly_name}}'))
-    .gridPos({ h: 8, w: 24, x: 0, y: 94 });
+    .gridPos({ h: 8, w: 24, x: 0, y: 110 });
 
   return [batteryTs];
 }

--- a/grafana/src/panels/spa.ts
+++ b/grafana/src/panels/spa.ts
@@ -7,7 +7,7 @@ import { VM_DS, vmMetric, vmExpr } from '../datasource.ts';
 import {
   greenThreshold, greenRedThresholds, paletteColor,
   legendBottom, tooltipMulti,
-  overrideDisplayAndColor,
+  overrideDisplayAndColor, overrideDisplayName,
   SPAN_NULLS_MS,
 } from '../helpers.ts';
 
@@ -31,7 +31,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
     ])
     .withTarget(vmMetric('A', 'spa_climate', 'current_temperature_value'))
     .withTarget(vmExpr('B', 'last_over_time(spa_temperature_range_state_text[$__interval])', 'state_text'))
-    .gridPos({ h: 8, w: 12, x: 0, y: 44 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 61 });
 
   // Spabadet (stat) - latest temp
   const spaStat = new StatBuilder()
@@ -43,7 +43,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('current_temperature_value', 'Temperatur', 'purple'),
     ])
     .withTarget(vmMetric('A', 'spa_climate', 'current_temperature_value'))
-    .gridPos({ h: 8, w: 4, x: 12, y: 44 });
+    .gridPos({ h: 8, w: 4, x: 12, y: 61 });
 
   // Spa Circulation (gauge)
   const spaCirculation = new GaugeBuilder()
@@ -51,8 +51,15 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
     .datasource(VM_DS)
     .unit('bool_on_off')
     .thresholds(greenThreshold())
+    .overrides([
+      overrideDisplayName('circulation', 'Circulation'),
+      overrideDisplayName('spa_pump_1_value', 'Jet 1'),
+      overrideDisplayName('spa_pump_2_value', 'Jet 2'),
+    ])
     .withTarget(vmExpr('A', 'last_over_time(spa_circulation_pump_value[$__interval])', 'circulation'))
-    .gridPos({ h: 8, w: 4, x: 16, y: 44 });
+    .withTarget(vmMetric('B', 'spa_pump_1', 'value'))
+    .withTarget(vmMetric('C', 'spa_pump_2', 'value'))
+    .gridPos({ h: 8, w: 4, x: 16, y: 61 });
 
   return [spaTs, spaStat, spaCirculation];
 }

--- a/grafana/src/panels/spa.ts
+++ b/grafana/src/panels/spa.ts
@@ -59,7 +59,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'last_over_time(spa_circulation_pump_value[$__interval])', 'circulation'))
     .withTarget(vmMetric('B', 'spa_pump_1', 'value'))
     .withTarget(vmMetric('C', 'spa_pump_2', 'value'))
-    .gridPos({ h: 8, w: 4, x: 16, y: 61 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 61 });
 
   return [spaTs, spaStat, spaCirculation];
 }

--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -37,7 +37,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('Limit', 'last_over_time(sum(sigenergy_discharge_control_limit_w[$__interval]) by ())', 'Limit'),
     )
-    .gridPos({ h: 8, w: 16, x: 0, y: 112 });
+    .gridPos({ h: 8, w: 16, x: 0, y: 128 });
 
   // 💾 Senaste VM-backup (stat, age in seconds)
   const vmBackup = new StatBuilder()
@@ -53,7 +53,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('A', 'now() - last_over_time(vm_backup_last_success_timestamp[$__interval])'),
     )
-    .gridPos({ h: 8, w: 8, x: 16, y: 112 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 128 });
 
   return [dischargeControl, vmBackup];
 }

--- a/grafana/src/panels/volvo.ts
+++ b/grafana/src/panels/volvo.ts
@@ -33,7 +33,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('B', 'last_over_time(ha_xc40_state_of_charge[$__interval])', 'soc'))
     .withTarget(vmExpr('C', 'last_over_time(ha_xc40_target_state_of_charge[$__interval])', 'target_soc'))
     .withTarget(vmExpr('D', 'last_over_time(ha_volvo_xc40_target_battery_charge_level_value[$__interval])', 'target_charge'))
-    .gridPos({ h: 8, w: 12, x: 0, y: 85 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 101 });
 
   // ⚡ XC40 Laddeffekt (timeseries) - charging power
   const chargingTs = new TimeseriesBuilder()
@@ -47,7 +47,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_charging_power_value[$__interval])', 'Laddeffekt'))
-    .gridPos({ h: 8, w: 6, x: 12, y: 85 });
+    .gridPos({ h: 8, w: 6, x: 12, y: 101 });
 
   // 🛣️ Räckvidd (stat) - distance to empty battery
   const distanceStat = new StatBuilder()
@@ -62,7 +62,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 100 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_distance_to_empty_battery_value[$__interval])', 'Räckvidd'))
-    .gridPos({ h: 8, w: 3, x: 18, y: 85 });
+    .gridPos({ h: 8, w: 3, x: 18, y: 101 });
 
   // 🔧 Service (stat) - time to service
   const serviceStat = new StatBuilder()
@@ -76,7 +76,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 90 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_time_to_service_value[$__interval])', 'Service'))
-    .gridPos({ h: 8, w: 3, x: 21, y: 85 });
+    .gridPos({ h: 8, w: 3, x: 21, y: 101 });
 
   return [batteryTs, chargingTs, distanceStat, serviceStat];
 }


### PR DESCRIPTION
## Summary
- Add dedicated **Spabadet** row (spa panels were incorrectly grouped under Poolen)
- Fix **Energi** row — panels were at y=46 but row header was at y=60, causing them to render outside the row
- Remove Ngenic Batteri and Ngenic Radiosignal panels
- Add `spa_pump_1` (Jet 1) and `spa_pump_2` (Jet 2) targets to Spa Circulation gauge
- Shift all downstream row headers (Volvo, Navimow, Eufy, Tapo, System) to maintain correct sequencing

## Test plan
- [ ] Verify Spabadet appears as its own collapsible row below Poolen
- [ ] Verify Energi row header appears above the SIG energy panels (Sigstore, Solceller, Urladdning, etc.)
- [ ] Verify Spa Circulation gauge shows Circulation, Jet 1, Jet 2
- [ ] Verify Poolen row no longer contains spa panels