### PR TITLE
feat(sigenergy-bridge): poll extended Modbus registers and emit ems_control metrics

### DIFF
--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -50,7 +50,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'red', value: 1 },
     ]))
     .withTarget(
-      vmExpr('A', 'last_over_time(sum(sigenergy_discharge_control_limit_w[$__interval]) by ())'),
+      vmExpr('A', 'last_over_time(sum(sigenergy_ems_control_max_discharge_limit_w[$__interval]) by ())'),
     )
     .gridPos({ h: 8, w: 4, x: 12, y: 128 });
 

--- a/sigenergy-bridge/internal/controller/loop.go
+++ b/sigenergy-bridge/internal/controller/loop.go
@@ -264,6 +264,7 @@ func readingsToPoints(host string, r *modbus.Readings, ts time.Time) []*metrics.
 			Tag("host", host).
 			Tag("operating_mode", r.OperatingMode).
 			Tag("model_type", r.ModelType).
+			Tag("running_state", r.RunningState).
 			Field("on_grid", boolInt(r.OnGrid)).
 			Field("grid_sensor_connected", boolInt(r.GridSensorConnected)).
 			At(ts),
@@ -278,12 +279,22 @@ func readingsToPoints(host string, r *modbus.Readings, ts time.Time) []*metrics.
 			Field("soc_percent", r.BatterySOCPct).
 			Field("power_to_battery_kw", r.ToBatteryKW).
 			Field("power_from_battery_kw", r.FromBatteryKW).
+			Field("avail_max_discharge_w", r.AvailMaxDischargeW).
 			At(ts),
 		metrics.NewPoint("sigenergy_pv_power").
 			Tag("host", host).
 			Tag("string", "total").
 			Field("power_kw", r.PVTotalKW).
 			At(ts),
+	}
+	if r.EMSControlOK {
+		points = append(points, metrics.NewPoint("sigenergy_ems_control").
+			Tag("host", host).
+			Field("remote_ems_enabled", boolInt(r.RemoteEMSEnabled)).
+			Field("control_mode", r.RemoteEMSControlMode).
+			Field("max_discharge_limit_w", r.ESSMaxDischargeLimitW).
+			Field("max_charge_limit_w", r.ESSMaxChargeLimitW).
+			At(ts))
 	}
 	for i, kw := range r.PVStringKW {
 		if kw <= 0 {

--- a/sigenergy-bridge/internal/modbus/sigen.go
+++ b/sigenergy-bridge/internal/modbus/sigen.go
@@ -24,6 +24,17 @@ type Readings struct {
 	FromBatteryKW       float64 // discharging (positive ESS power)
 	PVTotalKW           float64
 	PVStringKW          [4]float64 // per-string, plant-wide aggregation — 0 when unknown
+
+	// Extended plant block (30049..30051). Zero/empty when read fails.
+	AvailMaxDischargeW int    // 30049, available max ESS discharge, watts
+	RunningState       string // 30051, standby/running/fault/shutdown
+
+	// Remote EMS holding registers (40029..40036). Valid only when EMSControlOK.
+	EMSControlOK         bool
+	RemoteEMSEnabled     bool
+	RemoteEMSControlMode int
+	ESSMaxChargeLimitW   int // 40032
+	ESSMaxDischargeLimitW int // 40034
 }
 
 // Client is the Sigenergy surface consumed by the controller.
@@ -129,6 +140,15 @@ func (c *tcpClient) readInputLocked(addr, count uint16, slave uint8) ([]uint16, 
 	return c.client.ReadRegisters(addr, count, smb.INPUT_REGISTER)
 }
 
+// readHoldingLocked reads `count` holding registers. Must be called with the
+// connection already open (via withConnection).
+func (c *tcpClient) readHoldingLocked(addr, count uint16, slave uint8) ([]uint16, error) {
+	if err := c.client.SetUnitId(slave); err != nil {
+		return nil, err
+	}
+	return c.client.ReadRegisters(addr, count, smb.HOLDING_REGISTER)
+}
+
 // readInput is a convenience wrapper for single-call reads that don't
 // need a shared connection with other I/O.
 func (c *tcpClient) readInput(addr, count uint16, slave uint8) ([]uint16, error) {
@@ -224,7 +244,7 @@ func (c *tcpClient) writeU32KW(ctx context.Context, addr uint16, watts int, labe
 func (c *tcpClient) Read(ctx context.Context) (*Readings, error) {
 	rd := &Readings{}
 
-	var r1, r2 []uint16
+	var r1, r2, r3, r4 []uint16
 	err := c.withConnection(func() error {
 		var e error
 		// Plant block 1: 30003..30014 (12 regs: EMSWorkMode through SOC).
@@ -237,6 +257,10 @@ func (c *tcpClient) Read(ctx context.Context) (*Readings, error) {
 		if e != nil {
 			return fmt.Errorf("read plant block 30035: %w", e)
 		}
+		// Plant block 3: 30049..30051 (avail discharge U32 + running state). Non-fatal.
+		r3, _ = c.readInputLocked(RegPlantAvailMaxDischargeW, 3, SlaveIDPlant)
+		// Holding registers: 40029..40037 (remote EMS enable/mode + ESS limits). Non-fatal.
+		r4, _ = c.readHoldingLocked(RegPlantRemoteEMSEnable, 9, SlaveIDPlant)
 		// Inverter reads inline: model-type string (15 regs) + PV1..PV4
 		// voltage/current pairs. Errors here are non-fatal.
 		rd.ModelType = c.readModelTypeLocked(ctx)
@@ -286,6 +310,28 @@ func (c *tcpClient) Read(ctx context.Context) (*Readings, error) {
 		rd.FromBatteryKW = float64(-essW) / scaleKW
 	}
 
+	if len(r3) >= 3 {
+		rd.AvailMaxDischargeW = int(U32FromRegs(r3[0], r3[1]))
+		rd.RunningState = runningStateLabel(int(r3[2]))
+	} else {
+		rd.RunningState = "unknown"
+	}
+
+	// Layout of the 9-register holding block starting at 40029:
+	//   [0] 40029 RemoteEMSEnable   U16
+	//   [1] 40030 (reserved)
+	//   [2] 40031 RemoteEMSControlMode U16
+	//   [3..4] 40032..33 ESSMaxChargeLimitKW  U32 (raw = W)
+	//   [5..6] 40034..35 ESSMaxDischargeLimitKW U32 (raw = W)
+	//   [7..8] 40036..37 PVMaxPowerLimitKW U32 (unused here)
+	if len(r4) >= 7 {
+		rd.EMSControlOK = true
+		rd.RemoteEMSEnabled = r4[0] == 1
+		rd.RemoteEMSControlMode = int(r4[2])
+		rd.ESSMaxChargeLimitW = int(U32FromRegs(r4[3], r4[4]))
+		rd.ESSMaxDischargeLimitW = int(U32FromRegs(r4[5], r4[6]))
+	}
+
 	return rd, nil
 }
 
@@ -331,6 +377,21 @@ func (c *tcpClient) readPVStringsLocked(ctx context.Context, rd *Readings) {
 		if kw > 0 && kw < 50 {
 			rd.PVStringKW[i] = kw
 		}
+	}
+}
+
+func runningStateLabel(s int) string {
+	switch s {
+	case 0:
+		return "standby"
+	case 1:
+		return "running"
+	case 2:
+		return "fault"
+	case 3:
+		return "shutdown"
+	default:
+		return fmt.Sprintf("unknown(%d)", s)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Read three additional register blocks on every 60s poll:
  - **30049..30051**: available max discharge (W) + plant running state
  - **40029..40037**: remote EMS enable/mode + ESS charge/discharge limits (holding registers)
- New fields emitted per measurement:
  - `sigenergy_system_status`: `running_state` tag (standby/running/fault/shutdown)
  - `sigenergy_battery`: `avail_max_discharge_w`
  - `sigenergy_ems_control` *(new)*: `remote_ems_enabled`, `control_mode`, `max_discharge_limit_w`, `max_charge_limit_w`
- Grafana discharge-limit stat panel query updated to `sigenergy_ems_control_max_discharge_limit_w` so it updates continuously rather than only on clamp/unclamp events

## Test plan
- [ ] Deploy to rpi5 and verify `sigenergy_ems_control_max_discharge_limit_w` appears in VM after one poll interval (60s)
- [ ] Confirm `sigenergy_battery_avail_max_discharge_w` is populated
- [ ] Confirm `sigenergy_system_status` series gains `running_state` label
- [ ] Verify Grafana ⚡ Urladdningsgräns stat panel shows 9900 W at idle and 0 W when Wallbox is charging