### PR TITLE
feat(sigenergy-bridge): emit poll timing as sigenergy_bridge metric

### DIFF
--- a/sigenergy-bridge/internal/controller/loop.go
+++ b/sigenergy-bridge/internal/controller/loop.go
@@ -247,20 +247,21 @@ func (d *Deps) emitControl(ctx context.Context, reason string, limitW int, activ
 }
 
 func (d *Deps) poll(ctx context.Context) {
-	start := time.Now()
+	start := d.Now()
 	r, err := d.Modbus.Read(ctx)
 	if err != nil {
 		d.Log.WarnContext(ctx, "modbus read failed", "err", err)
 		return
 	}
-	points := readingsToPoints(d.Cfg.SigenergyHost, r, d.Now())
+	points := readingsToPoints(d.Cfg.SigenergyHost, r, start)
 	if err := d.Metrics.Write(ctx, points); err != nil {
 		d.Log.WarnContext(ctx, "metrics write (poll) failed", "err", err)
 	}
+	end := d.Now()
 	meta := metrics.NewPoint("sigenergy_bridge").
 		Tag("host", d.Cfg.SigenergyHost).
-		Field("duration_ms", time.Since(start).Milliseconds()).
-		At(d.Now())
+		Field("duration_ms", end.Sub(start).Milliseconds()).
+		At(end)
 	if err := d.Metrics.Write(ctx, []*metrics.Point{meta}); err != nil {
 		d.Log.WarnContext(ctx, "metrics write (meta) failed", "err", err)
 	}

--- a/sigenergy-bridge/internal/controller/loop.go
+++ b/sigenergy-bridge/internal/controller/loop.go
@@ -247,6 +247,7 @@ func (d *Deps) emitControl(ctx context.Context, reason string, limitW int, activ
 }
 
 func (d *Deps) poll(ctx context.Context) {
+	start := time.Now()
 	r, err := d.Modbus.Read(ctx)
 	if err != nil {
 		d.Log.WarnContext(ctx, "modbus read failed", "err", err)
@@ -255,6 +256,13 @@ func (d *Deps) poll(ctx context.Context) {
 	points := readingsToPoints(d.Cfg.SigenergyHost, r, d.Now())
 	if err := d.Metrics.Write(ctx, points); err != nil {
 		d.Log.WarnContext(ctx, "metrics write (poll) failed", "err", err)
+	}
+	meta := metrics.NewPoint("sigenergy_bridge").
+		Tag("host", d.Cfg.SigenergyHost).
+		Field("duration_ms", time.Since(start).Milliseconds()).
+		At(d.Now())
+	if err := d.Metrics.Write(ctx, []*metrics.Point{meta}); err != nil {
+		d.Log.WarnContext(ctx, "metrics write (meta) failed", "err", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Times the full poll cycle (Modbus read + metrics write) on every successful poll
- Writes `duration_ms` to the `sigenergy_bridge` measurement tagged with `host`
- Uses a separate `Metrics.Write` call so the timing metric itself is not included in the measured duration

## What changed

`poll()` in `internal/controller/loop.go` now captures `time.Now()` before the Modbus read and emits a `sigenergy_bridge{host=<inverter-ip>} duration_ms=<int>` point after the data write completes.

## Reviewer notes

The meta write is intentionally separate from the poll data write — if the data write fails the timing metric is still emitted. If the meta write itself fails it logs a warning and does not affect the poll result.