### PR TITLE
feat(grafana): add poll duration panel and fix discharge limit threshold

### DIFF
--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -51,8 +51,8 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .unit('watt')
     .decimals(0)
     .thresholds(thresholds([
-      { color: 'green', value: null },
-      { color: 'red', value: 1 },
+      { color: 'red', value: null },
+      { color: 'green', value: 1 },
     ]))
     .withTarget(
       vmExpr('A', 'last_over_time(sum(sigenergy_ems_control_max_discharge_limit_w[$__interval]) by ())'),
@@ -75,5 +75,21 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     )
     .gridPos({ h: 8, w: 8, x: 16, y: 136 });
 
-  return [dischargeControl, dischargeLimitStat, vmBackup];
+  // ⏱ Poll-tid Sigenergy (timeseries, duration_ms per poll cycle)
+  const pollDuration = new TimeseriesBuilder()
+    .title('⏱ Poll-tid Sigenergy')
+    .datasource(VM_DS)
+    .interval('1m')
+    .colorScheme(paletteColor())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .unit('ms')
+    .min(0)
+    .insertNulls(SPAN_NULLS_MS)
+    .withTarget(
+      vmExpr('Duration', 'last_over_time(sigenergy_bridge_duration_ms[$__interval])', 'Duration (ms)'),
+    )
+    .gridPos({ h: 8, w: 24, x: 0, y: 144 });
+
+  return [dischargeControl, dischargeLimitStat, vmBackup, pollDuration];
 }


### PR DESCRIPTION
## What changed

- **New panel**: Added \"⏱ Poll-tid Sigenergy\" timeseries panel at the end of the System row, visualising `sigenergy_bridge_duration_ms` — the end-to-end poll cycle duration (Modbus read + metrics write) emitted by the sigenergy-bridge (#357).
- **Threshold fix**: The \"⚡ Urladdningsgräns\" stat panel had inverted colours — 0 W was green and any positive limit was red. Flipped so 0 W = red and ≥1 W = green.

## Reviewer notes

- Only `grafana/src/panels/system.ts` is changed; `grafana/dist/dashboard.json` is regenerated from source and already uploaded to Grafana.
- The poll duration panel queries `last_over_time(sigenergy_bridge_duration_ms[$__interval])`, unit `ms`, min 0, with null-gap spanning at 10 min.