### PR TITLE
fix(scripts): resolve .env from main worktree root in git worktrees

### DIFF
--- a/scripts/vm-query.sh
+++ b/scripts/vm-query.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-TOKEN=$(grep '^INFLUX_TOKEN=' "$PROJECT_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
-DOMAIN=$(grep '^PROXY_DOMAIN=' "$PROJECT_DIR/https-proxy/.env" | cut -d'=' -f2-)
+# .env files are not committed, so in a git worktree they only exist in the main worktree root.
+MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+
+TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
+DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)
 BASE_URL="https://${DOMAIN}"
 
 usage() {

--- a/scripts/vm-rename.sh
+++ b/scripts/vm-rename.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-TOKEN=$(grep '^INFLUX_TOKEN=' "$PROJECT_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
-DOMAIN=$(grep '^PROXY_DOMAIN=' "$PROJECT_DIR/https-proxy/.env" | cut -d'=' -f2-)
+MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+
+TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
+DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)
 BASE_URL="https://${DOMAIN}"
 
 usage() {


### PR DESCRIPTION
## What changed

`vm-query.sh` and `vm-rename.sh` both resolve credentials by `grep`-ing `.env` files relative to `$PROJECT_DIR` (the script's parent directory). When running from a git worktree, `PROJECT_DIR` points to the worktree path rather than the main repo root. Since `.env` files are not committed, they only exist in the main worktree — causing the scripts to fail with `No such file or directory`.

## Fix

Use `git worktree list --porcelain` to find the main worktree root and read `.env` files from there. Falls back to `$PROJECT_DIR` if the command returns nothing.

## Testing

Run any `vm-query.sh` or `vm-rename.sh` command from inside a git worktree — credentials now resolve correctly instead of erroring.