### PR TITLE
fix(pool-planner): spot price timing + live baseline metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
   iot-fetcher:
     image: europe-docker.pkg.dev/filiplindqvist-com-ea66d/images/iot-fetcher:latest
     restart: unless-stopped
+    environment:
+      - TZ=Europe/Stockholm
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
   pool-pump-planner:
     image: europe-docker.pkg.dev/filiplindqvist-com-ea66d/images/pool-pump-planner:latest
     restart: unless-stopped
+    environment:
+      - TZ=Europe/Stockholm
     depends_on:
       - database-auth
     labels:

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -156,15 +156,18 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
         ],
       },
     ])
-    .withTarget(vmExpr('A', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run="backfill"})', 'planned_hours'))
-    .withTarget(vmExpr('B', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="backfill"})', 'expected_cost_sek'))
-    // Night/afternoon fixed-schedule baselines emitted by `backfill` alongside
-    // the MILP-optimal plan. Plotting all three on the same panel makes the
+    // anchor_date (backfill) and plan_date (live) are both removed so the two
+    // sources collapse into a single line. Live runs fill in the most recent
+    // days that the backfill subcommand hasn't covered yet.
+    .withTarget(vmExpr('A', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run=~"backfill|live"})', 'planned_hours'))
+    .withTarget(vmExpr('B', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run=~"backfill|live"})', 'expected_cost_sek'))
+    // Night/afternoon fixed-schedule baselines emitted alongside every plan
+    // (both backfill and live). Plotting all three on the same panel makes the
     // optimizer's value directly visible: the gap between yellow and the
     // baselines is SEK the planner saved vs a naive always-at-this-time rule.
-    .withTarget(vmExpr('D', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
-    .withTarget(vmExpr('E', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
-    .withTarget(vmExpr('C', 'sum without(anchor_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run="backfill"})', 'slack_hours'))
+    .withTarget(vmExpr('D', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
+    .withTarget(vmExpr('E', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
+    .withTarget(vmExpr('C', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
     .timeFrom('now-30d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -54,9 +54,12 @@ func runPlanner(cfg *Config) {
 	cfg.deletePlanForDate(planDate)
 
 	tags := map[string]string{"run": "live", "plan_date": planDate}
-	if _, _, err := plan(cfg, planStart.UTC(), tags); err != nil {
+	_, inputs, err := plan(cfg, planStart.UTC(), tags)
+	if err != nil {
 		log.Printf("[planner] run failed: %v", err)
+		return
 	}
+	runBaselines(cfg, inputs, planDate, cfg.DryRun)
 }
 
 func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, planInputs, error) {


### PR DESCRIPTION
## Summary
- **Fix spot price gap**: `iot-fetcher` container was running in UTC, causing the daily elpris run (`schedule.every().day.at('14:03')`) to fire at 16:03 Stockholm — nearly 2h *after* the pool-pump-planner queries for tomorrow's prices at 14:15 Stockholm. Adding `TZ=Europe/Stockholm` to the container restores the intended 14:03 Stockholm schedule (12:03 UTC), 12 min before the planner runs.
- **Live baseline metrics**: `runPlanner` now calls `runBaselines` after each live plan, writing `baseline_night` and `baseline_afternoon` series to VM daily. Previously these were only emitted by the `backfill` subcommand, leaving the 30-day comparison panel empty for recent days.
- **Grafana backfill panel**: queries updated to `run=~"backfill|live"` with `plan_date` added to `without()`, so live summaries fill in the gap for days not covered by a manual backfill.

## Test plan
- [ ] Restart `iot-fetcher` on rpi5 — verify `docker exec iot-fetcher date` shows Stockholm time
- [ ] At 14:03 Stockholm, confirm elpris logs fetch `<tomorrow>_SE4.json`
- [ ] At 14:15 Stockholm, confirm planner logs show `96/96 slots covered` instead of `4/96`
- [ ] Next day: backfill panel shows `baseline_night`/`baseline_afternoon` lines continuing to today

🤖 Generated with [Claude Code](https://claude.ai/claude-code)