### PR TITLE
fix(grafana): fix pool plan backfill panel time window and step

### DIFF
--- a/grafana/package.json
+++ b/grafana/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "generate": "node --env-file=.env src/index.ts",
-    "build": "GRAFANA_SKIP_UPLOAD=1 node src/index.ts",
+    "generate": "node --experimental-strip-types --env-file=.env src/index.ts",
+    "build": "GRAFANA_SKIP_UPLOAD=1 node --experimental-strip-types src/index.ts",
     "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
   },
   "engines": {

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -132,7 +132,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .thresholds(greenThreshold())
     .legend(legendBottom())
     .tooltip(tooltipMulti())
-    .insertNulls(SPAN_NULLS_MS)
+    .insertNulls(86_400_000)
+    .interval('1d')
     .overrides([
       {
         matcher: { id: 'byName', options: 'planned_hours' },
@@ -168,7 +169,7 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('D', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
     .withTarget(vmExpr('E', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
     .withTarget(vmExpr('C', 'sum without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
-    .timeFrom('now-30d')
+    .timeFrom('14d/d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 
   return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, pumpPlan, pumpPlanBackfill];


### PR DESCRIPTION
## Summary
- Set panel time window to `14d/d` (14 days, day-aligned) instead of `now-30d`
- Set min interval to `1d` so VictoriaMetrics looks back a full day per step — fixes sparse/disconnected data points for metrics emitted once per day
- Set `insertNulls` threshold to `86400000ms` (1d) to only disconnect lines when the gap exceeds a day
- Add `--experimental-strip-types` to `npm run build` and `npm run generate` scripts so they work without a wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)