### PR TITLE
feat(pool-planner): emit raw solar forecast alongside masked value

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -102,7 +102,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .overrides([
       overrideDisplayAndColor('on', 'Pump på', 'blue'),
       overrideDisplayAndColor('price_sek_per_kwh', 'Spotpris (SEK/kWh)', 'yellow'),
-      overrideDisplayAndColor('solar_kwh', 'Solprognos (kWh)', 'orange'),
+      overrideDisplayAndColor('solar_forecast_masked_kwh', 'Solprognos maskad (kWh)', 'orange'),
+      overrideDisplayAndColor('solar_forecast_kwh', 'Solprognos rådata (kWh)', 'light-orange'),
     ])
     // Strictly run="live" — the untagged legacy series in VM is a fossil
     // mixture of points from older deployments (e.g. when slot-size was 30m)
@@ -111,7 +112,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     // fallback on the same day) into one line.
     .withTarget(vmExpr('A', 'max(last_over_time(pool_iqpump_plan_on{run="live"}[$__interval]))', 'on'))
     .withTarget(vmExpr('B', 'max(last_over_time(pool_iqpump_plan_price_sek_per_kwh{run="live"}[$__interval]))', 'price_sek_per_kwh'))
-    .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_kwh{run="live"}[$__interval]))', 'solar_kwh'))
+    .withTarget(vmExpr('C', 'max(last_over_time(pool_iqpump_plan_solar_forecast_masked_kwh{run="live"}[$__interval]))', 'solar_forecast_masked_kwh'))
+    .withTarget(vmExpr('D', 'max(last_over_time(pool_iqpump_plan_solar_forecast_kwh{run="live"}[$__interval]))', 'solar_forecast_kwh'))
     // Show the full ISO week (Mon 00:00 -> Sun 23:59:59) so the 24h forecast
     // sits in context of the rest of the week. Grafana rejects negative
     // timeShift, so this week-anchored form is the documented workaround for

--- a/pool-pump-planner/backfill.go
+++ b/pool-pump-planner/backfill.go
@@ -143,7 +143,7 @@ func writeBaseline(cfg *Config, in planInputs, windowHours []int, runTag, anchor
 		// prints the schedule which is noisy for baselines; skip it entirely.
 		return stats.expectedCostSEK
 	}
-	if err := writePlan(cfg, in.Slots, sch, in.Prices, in.Solar, stats,
+	if err := writePlan(cfg, in.Slots, sch, in.Prices, in.Solar, in.SolarRaw, stats,
 		in.WaterTemp, in.WaterOK, len(windowHours), "baseline", "none", tags); err != nil {
 		// Non-fatal: baselines are comparison only, don't fail the day.
 		fmt.Printf("[backfill] baseline %s write failed: %v\n", runTag, err)

--- a/pool-pump-planner/planner.go
+++ b/pool-pump-planner/planner.go
@@ -33,7 +33,8 @@ type planReport struct {
 type planInputs struct {
 	Slots     []time.Time
 	Prices    []float64
-	Solar     []float64
+	Solar     []float64    // post-mask
+	SolarRaw  []float64    // pre-mask forecast
 	WaterTemp float64
 	WaterOK   bool
 }
@@ -72,19 +73,20 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 	}
 
 	prices := cfg.fetchHourlyPrices(slots)
-	var solar []float64
+	var solarRaw []float64
 	if cfg.Backfill {
-		solar = cfg.fetchSolarHistoricalKWh(slots)
+		solarRaw = cfg.fetchSolarHistoricalKWh(slots)
 	} else {
-		solar = cfg.fetchSolarForecast(slots)
+		solarRaw = cfg.fetchSolarForecast(slots)
 	}
-	solar = cfg.applySolarMask(solar, slots)
+	solar := cfg.applySolarMask(solarRaw, slots)
 	waterTemp, waterOK := cfg.fetchWaterTempAt(now)
 
 	inputs := planInputs{
 		Slots:     slots,
 		Prices:    prices,
 		Solar:     solar,
+		SolarRaw:  solarRaw,
 		WaterTemp: waterTemp,
 		WaterOK:   waterOK,
 	}
@@ -107,7 +109,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 		sch := fallbackSchedule(cfg, slots)
 		stats := fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags); err != nil {
+		if err := writePlan(cfg, slots, sch, prices, solar, solarRaw, stats, waterTemp, waterOK, tgt, "fallback", missing, extraTags); err != nil {
 			return planReport{}, inputs, err
 		}
 		return planReport{
@@ -131,7 +133,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 		sch = fallbackSchedule(cfg, slots)
 		stats = fallbackStats(cfg, sch, prices, solar)
 		tgt := len(cfg.FallbackNightHours) + len(cfg.FallbackAfternoonHours)
-		if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags); err != nil {
+		if err := writePlan(cfg, slots, sch, prices, solar, solarRaw, stats, waterTemp, waterOK, tgt, "fallback", "infeasible", extraTags); err != nil {
 			return planReport{}, inputs, err
 		}
 		return planReport{
@@ -144,7 +146,7 @@ func plan(cfg *Config, now time.Time, extraTags map[string]string) (planReport, 
 			OnHours:     onHoursFromSchedule(sch, slots, cfg.Timezone),
 		}, inputs, nil
 	}
-	if err := writePlan(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags); err != nil {
+	if err := writePlan(cfg, slots, sch, prices, solar, solarRaw, stats, waterTemp, waterOK, targetHours, "optimal", "", extraTags); err != nil {
 		return planReport{}, inputs, err
 	}
 	return planReport{
@@ -337,7 +339,7 @@ func solve(cfg *Config, slots []time.Time, prices, solar []float64, targetHours 
 // buildPlanPoints assembles the line-protocol points for one plan run:
 // 96 slot points plus a single summary point. Pure — no IO — so tests can
 // assert the tag/field shape directly.
-func buildPlanPoints(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+func buildPlanPoints(cfg *Config, slots []time.Time, sch []int, prices, solar, solarRaw []float64, stats planStats,
 	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) []*Point {
 	applyTags := func(p *Point) *Point {
 		for k, v := range extraTags {
@@ -360,11 +362,15 @@ func buildPlanPoints(cfg *Config, slots []time.Time, sch []int, prices, solar []
 		if len(prices) > t && !math.IsNaN(prices[t]) {
 			p.Field("price_sek_per_kwh", prices[t])
 		}
-		solarField := 0.0
+		maskedField := 0.0
 		if len(solar) > t {
-			solarField = solar[t]
+			maskedField = solar[t]
 		}
-		p.Field("solar_kwh", solarField)
+		rawField := 0.0
+		if len(solarRaw) > t {
+			rawField = solarRaw[t]
+		}
+		p.Field("solar_forecast_kwh", rawField).Field("solar_forecast_masked_kwh", maskedField)
 		points = append(points, p)
 	}
 
@@ -396,9 +402,9 @@ func buildPlanPoints(cfg *Config, slots []time.Time, sch []int, prices, solar []
 	return points
 }
 
-func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar []float64, stats planStats,
+func writePlan(cfg *Config, slots []time.Time, sch []int, prices, solar, solarRaw []float64, stats planStats,
 	waterTemp float64, waterOK bool, targetHours int, mode, missing string, extraTags map[string]string) error {
-	points := buildPlanPoints(cfg, slots, sch, prices, solar, stats, waterTemp, waterOK, targetHours, mode, missing, extraTags)
+	points := buildPlanPoints(cfg, slots, sch, prices, solar, solarRaw, stats, waterTemp, waterOK, targetHours, mode, missing, extraTags)
 
 	missingTag := missing
 	if missingTag == "" {

--- a/pool-pump-planner/planner_test.go
+++ b/pool-pump-planner/planner_test.go
@@ -95,7 +95,7 @@ func TestBuildPlanPointsOmitsNaNPrice(t *testing.T) {
 	stats := planStats{costPerSlot: []float64{0, 0, 0}}
 	tags := map[string]string{"run": "live", "plan_date": "2026-04-23"}
 
-	points := buildPlanPoints(cfg, slots, sch, prices, solar, stats, 0, false, 6, "optimal", "", tags)
+	points := buildPlanPoints(cfg, slots, sch, prices, solar, solar, stats, 0, false, 6, "optimal", "", tags)
 
 	if len(points) != len(slots)+1 {
 		t.Fatalf("expected %d points (slots + summary), got %d", len(slots)+1, len(points))


### PR DESCRIPTION
## Summary
- Add `solar_forecast_kwh` field (pre-mask raw forecast.solar value) to the `pool_iqpump_plan` per-slot points
- Rename existing `solar_kwh` field → `solar_forecast_masked_kwh` for clarity
- Add second target + override on the "Poolpump plan (24h)" Grafana panel so both series render side by side
- VM rename already executed: 101 historical series migrated from `pool_iqpump_plan_solar_kwh` → `pool_iqpump_plan_solar_forecast_masked_kwh`, old metric deleted

## Why
The `POOL_SOLAR_HOURLY_MASK` (0.5 multiplier on hours 0–10) is a rough estimate for shading from the house extension. Without the raw forecast also visible in VM/Grafana, there's nothing to calibrate the mask against — emitting both lets the ratio be tuned by comparing the two series alongside actual production.

## Test plan

### Local (pre-merge)
- [x] `go build ./...` clean in `pool-pump-planner/`
- [x] `go test ./...` passes (updated `TestBuildPlanPointsOmitsNaNPrice` for new signature)
- [x] `npm run build` regenerates `grafana/dist/dashboard.json` with the new target/override
- [x] VM rename dry-run + execute completed; old `pool_iqpump_plan_solar_kwh` is gone, new `pool_iqpump_plan_solar_forecast_masked_kwh` has 83 series in the 30d window

### Post-merge E2E
- [ ] Build + push image to registry, deploy on rpi5: `sudo docker compose -f docker-compose.yml -f docker-compose.local.yml up -d pool-pump-planner`
- [ ] Wait for next 14:15 Stockholm planner run (or trigger manually)
- [ ] Query VM: `pool_iqpump_plan_solar_forecast_kwh{run="live"}` and `pool_iqpump_plan_solar_forecast_masked_kwh{run="live"}` should both have the next plan_date
- [ ] Push Grafana dashboard (`cd grafana && npm run generate`) and confirm both lines render in "Poolpump plan (24h)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)