### PR TITLE
fix(grafana, scripts): pool plan grouping, charging-power panel, worktree env lookup

### DIFF
--- a/grafana/src/dashboard.ts
+++ b/grafana/src/dashboard.ts
@@ -21,6 +21,9 @@ export function buildDashboard() {
     .liveNow(true)
     .timepicker(
       new TimePickerBuilder().quickRanges([
+        new TimeOptionBuilder().display('2h').from('now-2h').to('now'),
+        new TimeOptionBuilder().display('6h').from('now-6h').to('now'),
+        new TimeOptionBuilder().display('12h').from('now-12h').to('now'),
         new TimeOptionBuilder().display('24h').from('now-24h').to('now'),
         new TimeOptionBuilder().display('48h').from('now-48h').to('now'),
         new TimeOptionBuilder().display('7 days').from('now-7d').to('now'),
@@ -67,8 +70,8 @@ export function buildDashboard() {
     builder.withPanel(panel);
   }
 
-  // Navimow row
-  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 109 }));
+  // Trädgård row (Navimow + soil humidity)
+  builder.withRow(new RowBuilder('Trädgård').gridPos({ h: 1, w: 24, x: 0, y: 109 }));
   for (const panel of navimowPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -162,15 +162,15 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     // anchor_date (backfill) and plan_date (live) are both removed so the two
     // sources collapse into a single line. Live runs fill in the most recent
     // days that the backfill subcommand hasn't covered yet.
-    .withTarget(vmExpr('A', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run=~"backfill|live"})', 'planned_hours'))
-    .withTarget(vmExpr('B', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run=~"backfill|live"})', 'expected_cost_sek'))
+    .withTarget(vmExpr('A', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_planned_hours{run=~"backfill|live"})', 'planned_hours'))
+    .withTarget(vmExpr('B', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run=~"backfill|live"})', 'expected_cost_sek'))
     // Night/afternoon fixed-schedule baselines emitted alongside every plan
     // (both backfill and live). Plotting all three on the same panel makes the
     // optimizer's value directly visible: the gap between yellow and the
     // baselines is SEK the planner saved vs a naive always-at-this-time rule.
-    .withTarget(vmExpr('D', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
-    .withTarget(vmExpr('E', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
-    .withTarget(vmExpr('C', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
+    .withTarget(vmExpr('D', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
+    .withTarget(vmExpr('E', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
+    .withTarget(vmExpr('C', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
     .timeFrom('14d/d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 

--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -24,11 +24,10 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .overrides([
       {
-        matcher: { id: 'byRegexp', options: 'Lim.*' },
+        matcher: { id: 'byRegexp', options: 'Ladd.*' },
         properties: [
           { id: 'custom.axisPlacement', value: 'right' },
           { id: 'unit', value: 'watt' },
-          { id: 'displayName', value: 'Gräns (W)' },
         ],
       },
     ])
@@ -40,7 +39,10 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
       vmExpr('Active', 'last_over_time(sum(sigenergy_discharge_control_active[$__interval]) by ())', 'Active'),
     )
     .withTarget(
-      vmExpr('Limit', 'last_over_time(sum(sigenergy_discharge_control_limit_w[$__interval]) by ())', 'Limit'),
+      vmExpr('Limit', 'last_over_time(sum(sigenergy_discharge_control_limit_w[$__interval]) by ())', 'Laddgräns'),
+    )
+    .withTarget(
+      vmExpr('Power', 'last_over_time(ha_wallbox_pulsar_max_sn_992144_charging_power_value[$__interval] * 1000)', 'Laddning'),
     )
     .gridPos({ h: 8, w: 12, x: 0, y: 136 });
 

--- a/pool-pump-planner/solar.go
+++ b/pool-pump-planner/solar.go
@@ -127,9 +127,11 @@ func (c *Config) applySolarMask(solar []float64, slots []time.Time) []float64 {
 	if len(c.SolarHourlyMask) != 24 {
 		return solar
 	}
+	n := min(len(solar), len(slots))
 	out := make([]float64, len(solar))
-	for i, s := range slots {
-		out[i] = solar[i] * c.SolarHourlyMask[s.In(c.Timezone).Hour()]
+	copy(out, solar)
+	for i := range n {
+		out[i] = solar[i] * c.SolarHourlyMask[slots[i].In(c.Timezone).Hour()]
 	}
 	return out
 }

--- a/scripts/vm-query.sh
+++ b/scripts/vm-query.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # .env files are not committed, so in a git worktree they only exist in the main worktree root.
-MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
-ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+# git-common-dir is shared across all worktrees; its parent is the canonical checkout.
+ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
 
 TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
 DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)

--- a/scripts/vm-rename.sh
+++ b/scripts/vm-rename.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
-ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
 
 TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
 DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)


### PR DESCRIPTION
## Summary
Three follow-ups from the previous round of fixes:

- **Pool plan panel** — drop `run` from the `max without(...)` grouping so backfill and live series collapse into a single line per metric instead of rendering as duplicates with separate legend entries
- **Discharge control panel** — add wallbox charging power as a third query (`Laddning`), rename `Limit` legend to `Laddgräns`, broaden the right-axis override regex from `Lim.*` to `Ladd.*`
- **Scripts** — replace unstable `git worktree list` parsing in `vm-query.sh` and `vm-rename.sh` with `git rev-parse --git-common-dir` (matches the pattern in `vm-shape.sh`); guard `applySolarMask` against mismatched slice lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)