### PR TITLE
fix(scripts): use git-common-dir for worktree env lookup

### DIFF
--- a/scripts/vm-query.sh
+++ b/scripts/vm-query.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # .env files are not committed, so in a git worktree they only exist in the main worktree root.
-MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
-ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+# git-common-dir is shared across all worktrees; its parent is the canonical checkout.
+ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
 
 TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
 DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)

--- a/scripts/vm-rename.sh
+++ b/scripts/vm-rename.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-MAIN_PROJECT_DIR="$(git -C "$PROJECT_DIR" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
-ENV_DIR="${MAIN_PROJECT_DIR:-$PROJECT_DIR}"
+ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
 
 TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
 DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)


### PR DESCRIPTION
## Summary
Replace `git worktree list` output parsing (order unstable, may pick a linked worktree without `.env`) with `git rev-parse --git-common-dir` to reliably locate the canonical checkout.

Matches the pattern already used in `vm-shape.sh`. Addresses Copilot review feedback on PR #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)