### PR TITLE
fix(pool-planner): guard applySolarMask against length mismatch

### DIFF
--- a/pool-pump-planner/solar.go
+++ b/pool-pump-planner/solar.go
@@ -127,9 +127,11 @@ func (c *Config) applySolarMask(solar []float64, slots []time.Time) []float64 {
 	if len(c.SolarHourlyMask) != 24 {
 		return solar
 	}
+	n := min(len(solar), len(slots))
 	out := make([]float64, len(solar))
-	for i, s := range slots {
-		out[i] = solar[i] * c.SolarHourlyMask[s.In(c.Timezone).Hour()]
+	copy(out, solar)
+	for i := range n {
+		out[i] = solar[i] * c.SolarHourlyMask[slots[i].In(c.Timezone).Hour()]
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
Iterate `min(len(solar), len(slots))` and copy the unmasked tail rather than indexing `solar[i]` for every slot. Avoids a panic if a future solar fetcher returns a slice shorter than the slot list.

Addresses Copilot review feedback on PR #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)