### PR TITLE
fix(grafana): drop run from pool plan grouping so backfill+live merge

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -162,15 +162,15 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     // anchor_date (backfill) and plan_date (live) are both removed so the two
     // sources collapse into a single line. Live runs fill in the most recent
     // days that the backfill subcommand hasn't covered yet.
-    .withTarget(vmExpr('A', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_planned_hours{run=~"backfill|live"})', 'planned_hours'))
-    .withTarget(vmExpr('B', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run=~"backfill|live"})', 'expected_cost_sek'))
+    .withTarget(vmExpr('A', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_planned_hours{run=~"backfill|live"})', 'planned_hours'))
+    .withTarget(vmExpr('B', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run=~"backfill|live"})', 'expected_cost_sek'))
     // Night/afternoon fixed-schedule baselines emitted alongside every plan
     // (both backfill and live). Plotting all three on the same panel makes the
     // optimizer's value directly visible: the gap between yellow and the
     // baselines is SEK the planner saved vs a naive always-at-this-time rule.
-    .withTarget(vmExpr('D', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
-    .withTarget(vmExpr('E', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
-    .withTarget(vmExpr('C', 'max without(anchor_date, plan_date, mode, missing_inputs) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
+    .withTarget(vmExpr('D', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_night"})', 'night_baseline_sek'))
+    .withTarget(vmExpr('E', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_expected_cost_sek{run="baseline_afternoon"})', 'afternoon_baseline_sek'))
+    .withTarget(vmExpr('C', 'max without(anchor_date, plan_date, mode, missing_inputs, run) (pool_iqpump_plan_summary_slack_hours{run=~"backfill|live"})', 'slack_hours'))
     .timeFrom('14d/d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 


### PR DESCRIPTION
## Summary
`max without(...)` was keeping `run` in the grouping label set, so backfill and live rendered as two separate lines per metric (visible as duplicate legend entries — \"Optimerad\" twice, \"Planerade timmar\" twice, \"Slack (h)\" twice).

Adding `run` to the without clause collapses them into one continuous line per metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)