### PR TITLE
feat(grafana): add 2h/6h/12h to dashboard quick ranges

### DIFF
--- a/grafana/src/dashboard.ts
+++ b/grafana/src/dashboard.ts
@@ -21,6 +21,9 @@ export function buildDashboard() {
     .liveNow(true)
     .timepicker(
       new TimePickerBuilder().quickRanges([
+        new TimeOptionBuilder().display('2h').from('now-2h').to('now'),
+        new TimeOptionBuilder().display('6h').from('now-6h').to('now'),
+        new TimeOptionBuilder().display('12h').from('now-12h').to('now'),
         new TimeOptionBuilder().display('24h').from('now-24h').to('now'),
         new TimeOptionBuilder().display('48h').from('now-48h').to('now'),
         new TimeOptionBuilder().display('7 days').from('now-7d').to('now'),


### PR DESCRIPTION
## Summary
Prepend 2h, 6h, and 12h to the dashboard time-picker quick ranges (above the existing 24h / 48h / 7d / 14d / 30d / 90d). Useful for inspecting recent inverter/poll behavior without manually punching in a custom range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)