### PR TITLE
feat(grafana): add HA soil sensor panels

### DIFF
--- a/grafana/src/panels/house.ts
+++ b/grafana/src/panels/house.ts
@@ -64,11 +64,15 @@ export function housePanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .overrides([
       overrideDisplayAndColor('temperature_C', 'Utomhustemperatur', 'blue'),
+      overrideDisplayAndColor('Marktemperatur', 'Marktemperatur', 'orange'),
     ])
     .withTarget(
       vmMetric('A', 'ngenic_node_sensor_measurement_value', 'temperature_C', {
         where: `"node_type" = 'CONTROLLER'`,
       }),
+    )
+    .withTarget(
+      vmExpr('B', 'avg_over_time(ha_soil_sensor_temperature_value[$__interval])', 'Marktemperatur'),
     )
     .gridPos({ h: 7, w: 8, x: 12, y: 1 });
 

--- a/grafana/src/panels/navimow.ts
+++ b/grafana/src/panels/navimow.ts
@@ -4,7 +4,7 @@ import type * as dashboard from '@grafana/grafana-foundation-sdk/dashboard';
 import { VM_DS, vmExpr } from '../datasource.ts';
 import {
   greenThreshold, paletteColor,
-  legendBottom, tooltipSingle,
+  legendBottom, tooltipSingle, tooltipMulti,
   overrideDisplayAndColor,
   SPAN_NULLS_MS,
 } from '../helpers.ts';
@@ -26,7 +26,24 @@ export function navimowPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('Navimow i206 AWD Battery', 'Navimow i206 AWD Battery', 'green'),
     ])
     .withTarget(vmExpr('A', 'last_over_time(ha_navimow_i206_awd_battery_value[$__interval])', '{{friendly_name}}'))
-    .gridPos({ h: 8, w: 24, x: 0, y: 110 });
+    .gridPos({ h: 8, w: 16, x: 0, y: 110 });
 
-  return [batteryTs];
+  // Markfuktighet (timeseries) - HA soil moisture sensor
+  const soilHumidity = new TimeseriesBuilder()
+    .title('Markfuktighet')
+    .datasource(VM_DS)
+    .unit('humidity')
+    .min(0)
+    .max(100)
+    .colorScheme(paletteColor())
+    .thresholds(greenThreshold())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .insertNulls(SPAN_NULLS_MS)
+    .withTarget(
+      vmExpr('A', 'avg_over_time(ha_soil_sensor_humidity_value[$__interval])', 'Dvärgpersika'),
+    )
+    .gridPos({ h: 8, w: 8, x: 16, y: 110 });
+
+  return [batteryTs, soilHumidity];
 }


### PR DESCRIPTION
## Summary
- Overlay HA soil temperature (`ha_soil_sensor_temperature_value`) on the outdoor temperature panel as 'Marktemperatur'
- Add a new 'Markfuktighet' soil moisture panel (`ha_soil_sensor_humidity_value`) next to the Navimow battery panel, resizing the battery panel from 24w to 16w

## Test plan
- [ ] Run `grafana-update` skill to regenerate dashboard JSON
- [ ] Verify the outdoor temp panel shows both controller temperature and ground temperature
- [ ] Verify the new Markfuktighet panel renders with soil humidity data
- [ ] Confirm Navimow battery panel resizes correctly without overlap