### PR TITLE
feat(sigenergy-bridge): clamp via discharge limit only

### DIFF
--- a/sigenergy-bridge/internal/controller/loop.go
+++ b/sigenergy-bridge/internal/controller/loop.go
@@ -1,16 +1,17 @@
 // Package controller wires the HA WebSocket listener, the Sigenergy Modbus
 // client, and the VictoriaMetrics writer into a single state machine:
 // clamp the battery's discharge to 0 while the Wallbox is charging, and
-// hand control back to the inverter's default EMS when idle.
+// restore the configured ceiling when idle.
 //
-// Clamp strategy: enable remote EMS (40029=1) and set control mode to
-// Standby (40031=0x01). In Standby the inverter neither charges nor
-// discharges the ESS, so any PV flows straight to loads/grid and the grid
-// covers the Wallbox without routing through the house battery. As a
-// defence-in-depth we also write max-discharge=0 (40034). On exit we do
-// the mirror: restore the discharge limit to the configured sentinel and
-// disable remote EMS, which hands control back to the user's normal mode
-// (typically max self-consumption or the Sigen AI mode).
+// Clamp strategy: write ESS max discharge limit (40034) only — to 0 for a
+// clamp, to the configured ceiling for an unclamp. We do NOT toggle
+// remote EMS (40029) or its control mode (40031). Touching 40029 forces
+// the inverter's EMS work mode (read-only register 30003) to "remote EMS"
+// while enabled, and on disable the firmware falls back to max self-
+// consumption rather than restoring the user's previous selection —
+// silently overwriting Sigen AI mode. SPC113+ firmware honours 40034
+// directly while EMS work mode stays at the user's choice, which is what
+// we want.
 package controller
 
 import (
@@ -54,12 +55,6 @@ func Run(ctx context.Context, d Deps) error {
 	if d.Now == nil {
 		d.Now = time.Now
 	}
-	priorMode, err := d.Modbus.ReadOperatingMode(ctx)
-	if err != nil {
-		d.Log.WarnContext(ctx, "could not read operating mode on startup; assuming max self-consumption",
-			"err", err)
-		priorMode = modbus.EMSMaxSelfConsumption
-	}
 
 	// Resolve the "unlimited" discharge ceiling. Priority:
 	//   1. Explicit SIGENERGY_DISCHARGE_UNLIMITED_W override (>0)
@@ -86,7 +81,6 @@ func Run(ctx context.Context, d Deps) error {
 	}
 
 	d.Log.InfoContext(ctx, "controller starting",
-		"prior_operating_mode", priorMode,
 		"discharge_unlimited_w", unlimitedW,
 		"discharge_unlimited_source", source,
 		"poll_interval", d.Cfg.PollInterval,
@@ -195,9 +189,6 @@ func isCharging(state string, chargingStates []string) bool {
 
 func (d *Deps) clamp(ctx context.Context, reason string) error {
 	d.Log.InfoContext(ctx, "clamping discharge", "reason", reason)
-	if err := d.Modbus.EnableRemoteEMS(ctx, modbus.ControlModeStandby); err != nil {
-		return fmt.Errorf("enable remote EMS: %w", err)
-	}
 	if err := d.Modbus.SetDischargeLimitW(ctx, 0); err != nil {
 		return fmt.Errorf("set discharge=0: %w", err)
 	}
@@ -210,9 +201,6 @@ func (d *Deps) unclamp(ctx context.Context, reason string) error {
 	d.Log.InfoContext(ctx, "restoring discharge", "reason", reason, "limit_w", d.Cfg.SigenergyUnlimitedW)
 	if err := d.Modbus.SetDischargeLimitW(ctx, d.Cfg.SigenergyUnlimitedW); err != nil {
 		return fmt.Errorf("restore discharge: %w", err)
-	}
-	if err := d.Modbus.DisableRemoteEMS(ctx); err != nil {
-		return fmt.Errorf("disable remote EMS: %w", err)
 	}
 	d.emitControl(ctx, reason, d.Cfg.SigenergyUnlimitedW, false)
 	d.poll(ctx)

--- a/sigenergy-bridge/internal/controller/loop_test.go
+++ b/sigenergy-bridge/internal/controller/loop_test.go
@@ -18,38 +18,22 @@ import (
 // --- fakes ---
 
 type fakeModbus struct {
-	mu                sync.Mutex
-	operatingMode     int
-	calls             []string // ordered trace of write calls (type:arg)
-	readCalls         atomic.Int32
+	mu        sync.Mutex
+	calls     []string // ordered trace of write calls (type:arg)
+	readCalls atomic.Int32
 }
 
 func (f *fakeModbus) Read(ctx context.Context) (*modbus.Readings, error) {
 	f.readCalls.Add(1)
 	return &modbus.Readings{
-		OperatingMode: "max_self_consumption",
+		OperatingMode: "sigen_ai",
 		ModelType:     "SigenStor",
 		BatterySOCPct: 55,
 		FromBatteryKW: 1.2,
 	}, nil
 }
-func (f *fakeModbus) ReadOperatingMode(ctx context.Context) (int, error) {
-	return f.operatingMode, nil
-}
 func (f *fakeModbus) ReadPlantMaxPowerW(ctx context.Context) (int, error) {
 	return 10000, nil
-}
-func (f *fakeModbus) EnableRemoteEMS(ctx context.Context, controlMode int) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.calls = append(f.calls, "enable")
-	return nil
-}
-func (f *fakeModbus) DisableRemoteEMS(ctx context.Context) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.calls = append(f.calls, "disable")
-	return nil
 }
 func (f *fakeModbus) SetDischargeLimitW(ctx context.Context, watts int) error {
 	f.mu.Lock()
@@ -62,7 +46,7 @@ func (f *fakeModbus) SetDischargeLimitW(ctx context.Context, watts int) error {
 	return nil
 }
 func (f *fakeModbus) SetChargingLimitW(ctx context.Context, watts int) error { return nil }
-func (f *fakeModbus) Close() error                                          { return nil }
+func (f *fakeModbus) Close() error                                           { return nil }
 
 type fakeHA struct {
 	events    chan ha.Event
@@ -113,7 +97,7 @@ func newCfg() *config.Config {
 }
 
 func newDeps(t *testing.T) (*fakeModbus, *fakeHA, *fakeMetrics, Deps) {
-	fm := &fakeModbus{operatingMode: modbus.EMSMaxSelfConsumption}
+	fm := &fakeModbus{}
 	fh := &fakeHA{events: make(chan ha.Event, 4), connected: make(chan bool, 4)}
 	fmx := &fakeMetrics{}
 	d := Deps{
@@ -137,10 +121,10 @@ func TestRun_ChargingStartedThenStopped(t *testing.T) {
 	go func() { done <- Run(ctx, d) }()
 
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Ready", NewState: "Charging"}
-	waitFor(t, func() bool { return callCount(fm) >= 2 })
+	waitFor(t, func() bool { return callCount(fm) >= 1 })
 
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Charging", NewState: "Ready"}
-	waitFor(t, func() bool { return callCount(fm) >= 4 })
+	waitFor(t, func() bool { return callCount(fm) >= 2 })
 
 	cancel()
 	select {
@@ -151,7 +135,7 @@ func TestRun_ChargingStartedThenStopped(t *testing.T) {
 
 	fm.mu.Lock()
 	defer fm.mu.Unlock()
-	want := []string{"enable", "discharge=0", "discharge=unlimited", "disable"}
+	want := []string{"discharge=0", "discharge=unlimited"}
 	if !equal(fm.calls, want) {
 		t.Errorf("calls: got %v want %v", fm.calls, want)
 	}
@@ -172,11 +156,11 @@ func TestRun_FailsafeOnHADisconnect(t *testing.T) {
 	go func() { done <- Run(ctx, d) }()
 
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Ready", NewState: "Charging"}
-	waitFor(t, func() bool { return callCount(fm) >= 2 })
+	waitFor(t, func() bool { return callCount(fm) >= 1 })
 
 	fh.connected <- false
 
-	waitFor(t, func() bool { return callCount(fm) >= 4 })
+	waitFor(t, func() bool { return callCount(fm) >= 2 })
 
 	cancel()
 	<-done
@@ -195,7 +179,7 @@ func TestRun_ShutdownRestoresIfClamped(t *testing.T) {
 	go func() { done <- Run(ctx, d) }()
 
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Ready", NewState: "Charging"}
-	waitFor(t, func() bool { return callCount(fm) >= 2 })
+	waitFor(t, func() bool { return callCount(fm) >= 1 })
 
 	cancel()
 	select {
@@ -207,8 +191,8 @@ func TestRun_ShutdownRestoresIfClamped(t *testing.T) {
 	fm.mu.Lock()
 	defer fm.mu.Unlock()
 	last := fm.calls[len(fm.calls)-1]
-	if last != "disable" {
-		t.Errorf("last call should be disable; got %v (%v)", last, fm.calls)
+	if last != "discharge=unlimited" {
+		t.Errorf("last call should restore discharge; got %v (%v)", last, fm.calls)
 	}
 	reasons := fmx.controlReasons()
 	if len(reasons) < 2 || reasons[len(reasons)-1] != "shutdown" {
@@ -231,10 +215,10 @@ func TestRun_MaxClampDurationReleases(t *testing.T) {
 	go func() { done <- Run(ctx, d) }()
 
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Ready", NewState: "Charging"}
-	waitFor(t, func() bool { return callCount(fm) >= 2 })
+	waitFor(t, func() bool { return callCount(fm) >= 1 })
 
 	// Do NOT disconnect HA — we want to verify max-duration (not failsafe).
-	waitFor(t, func() bool { return callCount(fm) >= 4 })
+	waitFor(t, func() bool { return callCount(fm) >= 2 })
 
 	cancel()
 	<-done
@@ -303,9 +287,9 @@ func TestRun_AutoDetectsDischargeCeiling(t *testing.T) {
 
 	// Drive one clamp/unclamp so we see the discharge writes.
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Ready", NewState: "Charging"}
-	waitFor(t, func() bool { return callCount(fm) >= 2 })
+	waitFor(t, func() bool { return callCount(fm) >= 1 })
 	fh.events <- ha.Event{EntityID: "sensor.wallbox_status", OldState: "Charging", NewState: "Ready"}
-	waitFor(t, func() bool { return callCount(fm) >= 4 })
+	waitFor(t, func() bool { return callCount(fm) >= 2 })
 
 	cancel()
 	<-done

--- a/sigenergy-bridge/internal/modbus/sigen.go
+++ b/sigenergy-bridge/internal/modbus/sigen.go
@@ -30,24 +30,21 @@ type Readings struct {
 	RunningState       string // 30051, standby/running/fault/shutdown
 
 	// Remote EMS holding registers (40029..40036). Valid only when EMSControlOK.
-	EMSControlOK         bool
-	RemoteEMSEnabled     bool
-	RemoteEMSControlMode int
-	ESSMaxChargeLimitW   int // 40032
+	EMSControlOK          bool
+	RemoteEMSEnabled      bool
+	RemoteEMSControlMode  int
+	ESSMaxChargeLimitW    int // 40032
 	ESSMaxDischargeLimitW int // 40034
 }
 
 // Client is the Sigenergy surface consumed by the controller.
 type Client interface {
 	Read(ctx context.Context) (*Readings, error)
-	ReadOperatingMode(ctx context.Context) (int, error)
 	// ReadPlantMaxPowerW returns the plant nameplate (register 30010) in
 	// watts. Used at startup to auto-size the "unlimited" discharge
 	// sentinel so we never write a value above what the inverter is built
 	// to handle.
 	ReadPlantMaxPowerW(ctx context.Context) (int, error)
-	EnableRemoteEMS(ctx context.Context, controlMode int) error
-	DisableRemoteEMS(ctx context.Context) error
 	SetDischargeLimitW(ctx context.Context, watts int) error
 	SetChargingLimitW(ctx context.Context, watts int) error
 	Close() error
@@ -84,10 +81,10 @@ func NewTCP(opts Opts) (Client, error) {
 }
 
 type tcpClient struct {
-	opts     Opts
-	client   *smb.ModbusClient
-	mu       sync.Mutex // simonvetter is not goroutine-safe
-	opened   bool
+	opts   Opts
+	client *smb.ModbusClient
+	mu     sync.Mutex // simonvetter is not goroutine-safe
+	opened bool
 }
 
 func (c *tcpClient) Close() error {
@@ -173,14 +170,6 @@ func (c *tcpClient) writeHolding(addr uint16, values []uint16, slave uint8) erro
 	})
 }
 
-func (c *tcpClient) ReadOperatingMode(ctx context.Context) (int, error) {
-	regs, err := c.readInput(RegPlantEMSWorkMode, 1, SlaveIDPlant)
-	if err != nil {
-		return 0, fmt.Errorf("read EMS work mode: %w", err)
-	}
-	return int(regs[0]), nil
-}
-
 func (c *tcpClient) ReadPlantMaxPowerW(ctx context.Context) (int, error) {
 	regs, err := c.readInput(RegPlantMaxActivePower, 2, SlaveIDPlant)
 	if err != nil {
@@ -188,27 +177,6 @@ func (c *tcpClient) ReadPlantMaxPowerW(ctx context.Context) (int, error) {
 	}
 	// U32 register pair, raw value = kW × 1000 = watts.
 	return int(U32FromRegs(regs[0], regs[1])), nil
-}
-
-func (c *tcpClient) EnableRemoteEMS(ctx context.Context, controlMode int) error {
-	c.opts.Log.InfoContext(ctx, "enabling remote EMS", "control_mode", controlMode)
-	return c.withConnection(func() error {
-		if err := c.client.SetUnitId(SlaveIDPlant); err != nil {
-			return err
-		}
-		if err := c.client.WriteRegister(RegPlantRemoteEMSEnable, 1); err != nil {
-			return fmt.Errorf("enable remote EMS: %w", err)
-		}
-		if err := c.client.WriteRegister(RegPlantRemoteEMSControlMode, uint16(controlMode)); err != nil {
-			return fmt.Errorf("set control mode: %w", err)
-		}
-		return nil
-	})
-}
-
-func (c *tcpClient) DisableRemoteEMS(ctx context.Context) error {
-	c.opts.Log.InfoContext(ctx, "disabling remote EMS")
-	return c.writeHolding(RegPlantRemoteEMSEnable, []uint16{0}, SlaveIDPlant)
 }
 
 func (c *tcpClient) SetDischargeLimitW(ctx context.Context, watts int) error {
@@ -424,19 +392,8 @@ type dryRunClient struct {
 func (d *dryRunClient) Read(ctx context.Context) (*Readings, error) {
 	return d.inner.Read(ctx)
 }
-func (d *dryRunClient) ReadOperatingMode(ctx context.Context) (int, error) {
-	return d.inner.ReadOperatingMode(ctx)
-}
 func (d *dryRunClient) ReadPlantMaxPowerW(ctx context.Context) (int, error) {
 	return d.inner.ReadPlantMaxPowerW(ctx)
-}
-func (d *dryRunClient) EnableRemoteEMS(ctx context.Context, controlMode int) error {
-	d.log.InfoContext(ctx, "dry-run: EnableRemoteEMS", "control_mode", controlMode)
-	return nil
-}
-func (d *dryRunClient) DisableRemoteEMS(ctx context.Context) error {
-	d.log.InfoContext(ctx, "dry-run: DisableRemoteEMS")
-	return nil
 }
 func (d *dryRunClient) SetDischargeLimitW(ctx context.Context, watts int) error {
 	d.log.InfoContext(ctx, "dry-run: SetDischargeLimitW", "watts", watts)

--- a/sigenergy-bridge/internal/modbus/sigen_test.go
+++ b/sigenergy-bridge/internal/modbus/sigen_test.go
@@ -44,12 +44,6 @@ func TestDryRun_AllowsWrites(t *testing.T) {
 	dry := DryRun(&stubClient{}, log)
 
 	ctx := context.Background()
-	if err := dry.EnableRemoteEMS(ctx, ControlModeStandby); err != nil {
-		t.Errorf("EnableRemoteEMS: %v", err)
-	}
-	if err := dry.DisableRemoteEMS(ctx); err != nil {
-		t.Errorf("DisableRemoteEMS: %v", err)
-	}
 	if err := dry.SetDischargeLimitW(ctx, 0); err != nil {
 		t.Errorf("SetDischargeLimitW: %v", err)
 	}
@@ -64,10 +58,7 @@ type stubClient struct{}
 func (stubClient) Read(ctx context.Context) (*Readings, error) {
 	return &Readings{}, nil
 }
-func (stubClient) ReadOperatingMode(ctx context.Context) (int, error)            { return 0, nil }
-func (stubClient) ReadPlantMaxPowerW(ctx context.Context) (int, error)            { return 10000, nil }
-func (stubClient) EnableRemoteEMS(ctx context.Context, controlMode int) error    { return nil }
-func (stubClient) DisableRemoteEMS(ctx context.Context) error                    { return nil }
-func (stubClient) SetDischargeLimitW(ctx context.Context, watts int) error       { return nil }
-func (stubClient) SetChargingLimitW(ctx context.Context, watts int) error        { return nil }
-func (stubClient) Close() error                                                  { return nil }
+func (stubClient) ReadPlantMaxPowerW(ctx context.Context) (int, error)     { return 10000, nil }
+func (stubClient) SetDischargeLimitW(ctx context.Context, watts int) error { return nil }
+func (stubClient) SetChargingLimitW(ctx context.Context, watts int) error  { return nil }
+func (stubClient) Close() error                                            { return nil }


### PR DESCRIPTION
## Summary
- Clamp now writes only `40034` (ESS max discharge limit). No more toggling `40029` (Remote EMS enable) or `40031` (control mode).
- Removes `ReadOperatingMode`, `EnableRemoteEMS`, `DisableRemoteEMS` from the modbus client surface — no remaining callers — and drops the dead `priorMode` startup read.
- 80 fewer lines, surface area shrinks proportionally.

## Why

Toggling remote EMS forces the inverter's read-only EMS work mode (`30003`) to `remote_ems` while enabled. On disable, firmware falls back to `max_self_consumption` instead of restoring the user's previous mode — **silently overwriting Sigen AI mode after every Wallbox cycle.**

VictoriaMetrics confirmed the issue yesterday: every clamp/unclamp cycle on 2026-05-01 ended with `operating_mode=max_self_consumption` even though the user's app setting was Sigen AI.

SPC113+ firmware honours `40034` directly while EMS work mode stays at the user's choice. Live-tested on this plant (firmware `V100R001C21SPC113`):

| Step | EMS mode (30003) | Remote EMS (40029) | 40034 |
|---|---|---|---|
| baseline | sigen_ai | 0 | 9900 W |
| after `40034 ← 0` | **sigen_ai** | **0** | 0 W |
| 12s of samples | sigen_ai | 0 | 0 W |
| restore to 9900 | sigen_ai | 0 | 9900 W |

EMS work mode never moved. The firmware quirk that broke AI mode is bypassed entirely.

## Test plan

### Local (pre-merge) — done
- `cd sigenergy-bridge && go vet ./...` ✅
- `cd sigenergy-bridge && go test ./...` ✅ (controller, modbus, config, ha, metrics)
- `gofmt -l` clean on touched files

### Post-merge E2E
1. `cd sigenergy-bridge && make build && make push` to publish the new image.
2. On rpi5: set `DRY_RUN=false` in `~/iot-fetcher/sigenergy-bridge/.env` (currently `true` — set as a safety hold while this PR was being developed). Then `sudo docker compose -f docker-compose.yml -f docker-compose.local.yml up -d sigenergy-bridge`.
3. Wait for next Wallbox charging session.
4. Verify in VictoriaMetrics:
   - `sigenergy_ems_control_remote_ems_enabled` stays at 0 (was toggling 1↔0 before).
   - `sigenergy_system_status_on_grid{operating_mode="sigen_ai"}` stays present throughout the cycle (no flips to `max_self_consumption` or `remote_ems`).
   - `sigenergy_ems_control_max_discharge_limit_w` swings 9900 → 0 → 9900 across the cycle.