### PR TITLE
feat(aquatemp): derive power_usage from compressor current × voltage

### DIFF
--- a/fetcher-core/python/src/aquatemp.py
+++ b/fetcher-core/python/src/aquatemp.py
@@ -17,10 +17,18 @@ CODES = {
     'T03': 'temp_outgoing',
     'T05': 'temp_ambient',
     'R02': 'temp_target',
-    'T12': 'power_usage',
     'power': 'power_mode',
-    'Manual-mute': 'silenced'
+    'Manual-mute': 'silenced',
 }
+
+# Codes we fetch but don't emit as their own fields — used only as inputs
+# to the derived `power_usage` metric (compressor current × supply voltage).
+# Per the radical-squared/aquatemp HA integration's parameter map, T06 is
+# amper and T13 is volt; T12 (which we previously mislabelled as power) is
+# actually a temperature, hence the rename.
+DERIVATION_CODES = ('T06', 'T13')
+
+PROTOCOL_CODES = list(CODES.keys()) + list(DERIVATION_CODES)
 
 
 def aquatemp():
@@ -103,7 +111,7 @@ def getDeviceData(token: str, deviceCode: str) -> Optional[list[Dict[str, str]]]
     deviceData_response = requests.post(
         f"{cloudurl}/app/device/getDataByCode?lang=en", headers=headers, json={
             'deviceCode': deviceCode,
-            'protocalCodes': list(CODES.keys()),
+            'protocalCodes': PROTOCOL_CODES,
             'appId': '14',
         }, timeout=30)
     if deviceData_response.status_code != 200:
@@ -147,21 +155,35 @@ def _aquatemp():
                 f"[aquatemp] Device {deviceCode} has no data, skipping.")
             continue
 
+        # Collect every returned value first so we can both write the
+        # straightforward fields and derive composites (e.g. power = I × V).
+        values: Dict[str, float] = {}
+        for deviceDataObject in deviceData:
+            code = deviceDataObject['code']
+            raw = deviceDataObject.get('value')
+            if raw in (None, ''):
+                logger.warning(
+                    f"[aquatemp] Device {deviceCode} has no value for {code}, skipping.")
+                continue
+            values[code] = float(raw)
+
         p = Point('aqua_temp')\
             .tag('device_name', device['deviceNickName'])\
             .tag('device_id', device['deviceId'])\
             .tag('device_model', device['custModel'])
 
         has_fields = False
-        for deviceDataObject in deviceData:
-            metricName = CODES.get(
-                deviceDataObject['code'], 'unknown_' + deviceDataObject['code'])
-            if deviceDataObject.get('value'):
-                p = p.field(metricName, float(deviceDataObject['value']))
+        for code, metricName in CODES.items():
+            if code in values:
+                p = p.field(metricName, values[code])
                 has_fields = True
-            else:
-                logger.warning(
-                    f"[aquatemp] Device {deviceCode} has no value for {metricName}, skipping.")
+
+        # Derived input power: compressor current (T06, A) × supply voltage
+        # (T13, V). Stored under the same `power_usage` field name as before
+        # but now reflects real instantaneous draw instead of the misread T12.
+        if 'T06' in values and 'T13' in values:
+            p = p.field('power_usage', values['T06'] * values['T13'])
+            has_fields = True
 
         if has_fields:
             points.append(p)

--- a/fetcher-core/python/src/aquatemp.py
+++ b/fetcher-core/python/src/aquatemp.py
@@ -23,10 +23,12 @@ CODES = {
 
 # Codes we fetch but don't emit as their own fields — used only as inputs
 # to the derived `power_usage` metric (compressor current × supply voltage).
-# Per the radical-squared/aquatemp HA integration's parameter map, T06 is
-# amper and T13 is volt; T12 (which we previously mislabelled as power) is
-# actually a temperature, hence the rename.
-DERIVATION_CODES = ('T06', 'T13')
+# Per the radical-squared/aquatemp HA integration's per-device entity map
+# (entity_description.1442284873216843776.json), T07 is "Compressor current
+# Detect [A]" and T14 is "Inverter plate AC voltage [V]". The legacy default
+# parameter map said T06=amper / T13=volt, which is correct for older units
+# but NOT this device — verified live: T07 reports 9.5, T14 reports 222 (V).
+DERIVATION_CODES = ('T07', 'T14')
 
 PROTOCOL_CODES = list(CODES.keys()) + list(DERIVATION_CODES)
 
@@ -178,11 +180,12 @@ def _aquatemp():
                 p = p.field(metricName, values[code])
                 has_fields = True
 
-        # Derived input power: compressor current (T06, A) × supply voltage
-        # (T13, V). Stored under the same `power_usage` field name as before
-        # but now reflects real instantaneous draw instead of the misread T12.
-        if 'T06' in values and 'T13' in values:
-            p = p.field('power_usage', values['T06'] * values['T13'])
+        # Derived input power: compressor current (T07, A) × inverter plate
+        # AC voltage (T14, V). Stored under the same `power_usage` field name
+        # as before but now reflects real instantaneous draw instead of the
+        # previous T12-as-power misread (T12 is actually fan target RPM).
+        if 'T07' in values and 'T14' in values:
+            p = p.field('power_usage', values['T07'] * values['T14'])
             has_fields = True
 
         if has_fields:


### PR DESCRIPTION
## Summary
- `aqua_temp_power_usage` is now computed as **T07 × T14** (compressor current A × inverter plate AC voltage V) instead of being read from T12.
- T12 was misread as power for ages — it's actually **target fan motor RPM** (which is why the value was always 600/700/800: those are common AquaTemp fan target speeds, not watts).
- Adds T07 and T14 to the protocol-codes request list as derivation inputs (not emitted as their own fields).

## Why
`aqua_temp_power_usage` was reporting ~800 W when the heat pump was running. Tibber showed ~4 kW house draw with circulation pump (~365 W) + Q30 running, leaving a 2-3 kW gap. Tracing back through the radical-squared/aquatemp HA integration's per-device entity descriptions confirmed:

| Code | Default-map (older devices) | Q30-style (entity_description.1442284873216843776) |
|---|---|---|
| T06 | amper | **Exhaust Temp [°C]** |
| T07 | percentage | **Compressor current Detect [A]** |
| T12 | temperature | **Target speed of fan motor [r]** |
| T13 | volt | Over heat after compen. [°C] |
| T14 | temperature | **Inverter plate AC voltage [V]** |

Verified live on this plant:
```
T02=13.0  T03=15.5  T05=14.5  T07=9.5  T14=222  T17=796 (fan RPM)
power_usage = 9.5 × 222 = 2109 W
```

That's a believable Q30 draw at moderate compressor speed.

## Test plan

### Local — done
- `python3 -c 'import ast; ast.parse(open("fetcher-core/python/src/aquatemp.py").read())'` ✅
- Built image, deployed to rpi5, ran `_aquatemp()` manually, saw `aqua_temp_power_usage = 2109` in VM (was 800 before).

### Post-merge
No additional steps needed — already deployed via `make push` + compose pull. Monitor over the next day and confirm power_usage tracks the heat pump's actual draw (compare against Tibber's whole-house metric when the heat pump cycles).