### PR TITLE
fix(grafana): make pool_iqpump_motordata_power the first Pool Energi query

### DIFF
--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -63,8 +63,8 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .fillOpacity(10)
     .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
-    .withTarget(vmMetric('A', 'aqua_temp', 'power_usage'))
-    .withTarget(vmExpr('B', 'avg_over_time(pool_iqpump_motordata_power[$__interval])', 'pool_iqpump_motordata_power'))
+    .withTarget(vmExpr('A', 'avg_over_time(pool_iqpump_motordata_power[$__interval])', 'pool_iqpump_motordata_power'))
+    .withTarget(vmMetric('B', 'aqua_temp', 'power_usage'))
     .gridPos({ h: 7, w: 7, x: 17, y: 30 });
 
   // Pumpvarvtal (stat)

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -7,7 +7,7 @@ import { VM_DS, vmMetric, vmExpr } from '../datasource.ts';
 import {
   greenRedThresholds, greenThreshold, thresholds, paletteColor,
   legendBottom, tooltipSingle, tooltipMulti,
-  overrideDisplayAndColor,
+  overrideDisplayAndColor, overrideDisplayName,
   SPAN_NULLS_MS,
 } from '../helpers.ts';
 
@@ -63,6 +63,10 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .fillOpacity(10)
     .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
+    .overrides([
+      overrideDisplayName('pool_iqpump_motordata_power', 'Circulationspump'),
+      overrideDisplayName('power_usage', 'Värmepump'),
+    ])
     .withTarget(vmExpr('A', 'avg_over_time(pool_iqpump_motordata_power[$__interval])', 'pool_iqpump_motordata_power'))
     .withTarget(vmMetric('B', 'aqua_temp', 'power_usage'))
     .gridPos({ h: 7, w: 7, x: 17, y: 30 });


### PR DESCRIPTION
Swaps the query order in the Pool Energi panel so `pool_iqpump_motordata_power` is query A and `aqua_temp.power_usage` is query B.