### PR TITLE
feat(grafana): add YTD pool electricity cost panels

### DIFF
--- a/grafana/src/dashboard.ts
+++ b/grafana/src/dashboard.ts
@@ -53,44 +53,44 @@ export function buildDashboard() {
   }
 
   // Spabadet row
-  builder.withRow(new RowBuilder('Spabadet').gridPos({ h: 1, w: 24, x: 0, y: 60 }));
+  builder.withRow(new RowBuilder('Spabadet').gridPos({ h: 1, w: 24, x: 0, y: 68 }));
   for (const panel of spaPanels()) {
     builder.withPanel(panel);
   }
 
   // Energi row
-  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 69 }));
+  builder.withRow(new RowBuilder('Energi').gridPos({ h: 1, w: 24, x: 0, y: 77 }));
   for (const panel of energyPanels()) {
     builder.withPanel(panel);
   }
 
   // Volvo XC40 row
-  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 100 }));
+  builder.withRow(new RowBuilder('Volvo XC40').gridPos({ h: 1, w: 24, x: 0, y: 108 }));
   for (const panel of volvoPanels()) {
     builder.withPanel(panel);
   }
 
   // Navimow row
-  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 109 }));
+  builder.withRow(new RowBuilder('Navimow').gridPos({ h: 1, w: 24, x: 0, y: 117 }));
   for (const panel of navimowPanels()) {
     builder.withPanel(panel);
   }
 
   // Eufy Cameras row (collapsed)
-  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 118 });
+  const eufyRow = new RowBuilder('Eufy Cameras').collapsed(true).gridPos({ h: 1, w: 24, x: 0, y: 126 });
   for (const panel of eufyPanels()) {
     eufyRow.withPanel(panel);
   }
   builder.withRow(eufyRow);
 
   // Tapo row
-  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 127 }));
+  builder.withRow(new RowBuilder('Tapo').gridPos({ h: 1, w: 24, x: 0, y: 135 }));
   for (const panel of tapoPanels()) {
     builder.withPanel(panel);
   }
 
   // System row (meta metrics)
-  builder.withRow(new RowBuilder('System').gridPos({ h: 1, w: 24, x: 0, y: 135 }));
+  builder.withRow(new RowBuilder('System').gridPos({ h: 1, w: 24, x: 0, y: 143 }));
   for (const panel of systemPanels()) {
     builder.withPanel(panel);
   }

--- a/grafana/src/panels/energy.ts
+++ b/grafana/src/panels/energy.ts
@@ -31,7 +31,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipSingle())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'sigenergy_battery', 'soc_percent'))
-    .gridPos({ h: 8, w: 9, x: 0, y: 70 });
+    .gridPos({ h: 8, w: 9, x: 0, y: 78 });
 
   // ☀️ Solceller effekt (stat)
   const solar = new StatBuilder()
@@ -46,7 +46,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
         where: `"string" = 'total'`,
       }),
     )
-    .gridPos({ h: 8, w: 4, x: 9, y: 70 });
+    .gridPos({ h: 8, w: 4, x: 9, y: 78 });
 
   // 🪫 Urladdning (stat)
   const discharge = new StatBuilder()
@@ -57,7 +57,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .max(10)
     .thresholds(greenThreshold())
     .withTarget(vmMetric('A', 'sigenergy_battery', 'power_to_battery_kw'))
-    .gridPos({ h: 8, w: 4, x: 13, y: 70 });
+    .gridPos({ h: 8, w: 4, x: 13, y: 78 });
 
   // ⚡️ Energiförbrukning - simple (timeseries, mean+max)
   const energySimple = new TimeseriesBuilder()
@@ -72,7 +72,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('DjUv', 'tibber', 'power'))
     .withTarget(vmMetric('B', 'tibber', 'power', { agg: 'MAX' }))
-    .gridPos({ h: 8, w: 7, x: 17, y: 70 });
+    .gridPos({ h: 8, w: 7, x: 17, y: 78 });
 
   // ⚡️ Energiförbrukning - detailed (timeseries, 4 queries)
   const energyDetailed = new TimeseriesBuilder()
@@ -124,7 +124,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
         'power_kw',
       ),
     )
-    .gridPos({ h: 8, w: 9, x: 0, y: 78 });
+    .gridPos({ h: 8, w: 9, x: 0, y: 86 });
 
   // ⚡️ Energiförbrukning (stat)
   const energyStat = new StatBuilder()
@@ -133,7 +133,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .unit('kwatth')
     .thresholds(energyThresholds())
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption', { agg: 'LAST_VALUE' }))
-    .gridPos({ h: 8, w: 3, x: 9, y: 78 });
+    .gridPos({ h: 8, w: 3, x: 9, y: 86 });
 
   // ⚡️ Energiförbrukning per fas (timeseries)
   const energyPhases = new TimeseriesBuilder()
@@ -153,7 +153,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'avg_over_time(tibber_powerL1[$__interval])', 'powerL1'))
     .withTarget(vmExpr('B', 'avg_over_time(tibber_powerL2[$__interval])', 'powerL2'))
     .withTarget(vmExpr('C', 'avg_over_time(tibber_powerL3[$__interval])', 'powerL3'))
-    .gridPos({ h: 8, w: 12, x: 12, y: 78 });
+    .gridPos({ h: 8, w: 12, x: 12, y: 86 });
 
   // Dygnskostnad 30d (bar chart)
   const dailyCost30d = new TimeseriesBuilder()
@@ -177,7 +177,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedCost', { agg: 'MAX' }))
     .timeFrom('30d/d')
-    .gridPos({ h: 6, w: 7, x: 0, y: 86 });
+    .gridPos({ h: 6, w: 7, x: 0, y: 94 });
 
   // Dygnsförbrukning 30d (bar chart)
   const dailyConsumption30d = new TimeseriesBuilder()
@@ -200,7 +200,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption', { agg: 'MAX' }))
     .timeFrom('30d/d')
-    .gridPos({ h: 6, w: 9, x: 7, y: 86 });
+    .gridPos({ h: 6, w: 9, x: 7, y: 94 });
 
   // Veckopris (timeseries, stepAfter, 7d)
   const weeklyPrice = new TimeseriesBuilder()
@@ -229,7 +229,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
       }),
     )
     .timeFrom('7d/d')
-    .gridPos({ h: 6, w: 8, x: 16, y: 86 });
+    .gridPos({ h: 6, w: 8, x: 16, y: 94 });
 
   // Dygnskostnad 1d (timeseries)
   const dailyCost1d = new TimeseriesBuilder()
@@ -250,7 +250,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedCost'))
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 7, x: 0, y: 92 });
+    .gridPos({ h: 8, w: 7, x: 0, y: 100 });
 
   // Dygnsförbrukning 1d (timeseries)
   const dailyConsumption1d = new TimeseriesBuilder()
@@ -271,7 +271,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmMetric('A', 'tibber', 'accumulatedConsumption'))
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 9, x: 7, y: 92 });
+    .gridPos({ h: 8, w: 9, x: 7, y: 100 });
 
   // Dygnspris (timeseries, stepAfter, 1d)
   const dailyPrice = new TimeseriesBuilder()
@@ -299,7 +299,7 @@ export function energyPanels(): cog.Builder<dashboard.Panel>[] {
       }),
     )
     .timeFrom('1d/d')
-    .gridPos({ h: 8, w: 8, x: 16, y: 92 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 100 });
 
   return [
     battery, solar, discharge, energySimple,

--- a/grafana/src/panels/eufy.ts
+++ b/grafana/src/panels/eufy.ts
@@ -23,7 +23,7 @@ export function eufyPanels(): cog.Builder<dashboard.Panel>[] {
     .withTransformation({ id: 'labelsToFields', options: { valueLabel: 'device_name' } })
     .withTarget(vmMetric('A', 'eufy_device', 'battery'))
     .timeFrom('7d/d')
-    .gridPos({ h: 8, w: 8, x: 0, y: 119 });
+    .gridPos({ h: 8, w: 8, x: 0, y: 127 });
 
   // Eufy Battery Temperature (timeseries + labelsToFields)
   const batteryTemp = new TimeseriesBuilder()
@@ -39,7 +39,7 @@ export function eufyPanels(): cog.Builder<dashboard.Panel>[] {
     .withTransformation({ id: 'labelsToFields', options: { valueLabel: 'device_name' } })
     .withTarget(vmMetric('A', 'eufy_device', 'batteryTemperature'))
     .timeFrom('7d/d')
-    .gridPos({ h: 8, w: 8, x: 8, y: 119 });
+    .gridPos({ h: 8, w: 8, x: 8, y: 127 });
 
   // Eufy WiFi Signal (timeseries, dBm)
   const wifiRssi = new TimeseriesBuilder()
@@ -59,7 +59,7 @@ export function eufyPanels(): cog.Builder<dashboard.Panel>[] {
     .withTransformation({ id: 'labelsToFields', options: { valueLabel: 'device_name' } })
     .withTarget(vmMetric('A', 'eufy_device', 'wifiRssi'))
     .timeFrom('7d/d')
-    .gridPos({ h: 8, w: 8, x: 16, y: 119 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 127 });
 
   return [batteryTs, batteryTemp, wifiRssi];
 }

--- a/grafana/src/panels/house.ts
+++ b/grafana/src/panels/house.ts
@@ -197,7 +197,7 @@ export function tapoPanels(): cog.Builder<dashboard.Panel>[] {
       ),
     )
     .timeFrom('7d/d')
-    .gridPos({ h: 7, w: 12, x: 0, y: 128 });
+    .gridPos({ h: 7, w: 12, x: 0, y: 136 });
 
   return [tapoOnline];
 }

--- a/grafana/src/panels/navimow.ts
+++ b/grafana/src/panels/navimow.ts
@@ -26,7 +26,7 @@ export function navimowPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('Navimow i206 AWD Battery', 'Navimow i206 AWD Battery', 'green'),
     ])
     .withTarget(vmExpr('A', 'last_over_time(ha_navimow_i206_awd_battery_value[$__interval])', '{{friendly_name}}'))
-    .gridPos({ h: 8, w: 16, x: 0, y: 110 });
+    .gridPos({ h: 8, w: 16, x: 0, y: 118 });
 
   // Markfuktighet (timeseries) - HA soil moisture sensor
   const soilHumidity = new TimeseriesBuilder()
@@ -43,7 +43,7 @@ export function navimowPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('A', 'avg_over_time(ha_soil_sensor_humidity_value[$__interval])', 'Dvärgpersika'),
     )
-    .gridPos({ h: 8, w: 8, x: 16, y: 110 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 118 });
 
   return [batteryTs, soilHumidity];
 }

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -211,6 +211,77 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .timeFrom('14d/d')
     .gridPos({ h: 8, w: 12, x: 12, y: 52 });
 
+  // Pool kostnad — actual pump cost using SE4 spot price plus Swedish
+  // grid+tax loading: (spot + 0.2584 transferfee + 0.36 energiskatt) * 1.25 VAT,
+  // matching pool-pump-planner config defaults (March 2026 E.ON invoice).
+  // Subquery resamples at 5m to cover the heat pump's 5m scrape interval; the
+  // [5m] inner lookback ensures every step lands on a real sample. * 5 / 60
+  // converts SEK/h × 5-min samples into SEK accumulated per bucket. The inner
+  // sum() collapses incidental label variants (e.g. a stray device="00" series
+  // alongside the real device="17") that show up over a YTD range so the
+  // legend stays a single line per pump.
+  const POOL_COST_FEES = '0.6184'; // 0.2584 transferfee + 0.36 energiskatt
+  const POOL_COST_VAT = '1.25';    // 25% moms applied on top of spot+fees
+  const poolCostExpr = (powerMetric: string): string =>
+    `sum_over_time((sum(avg_over_time(${powerMetric}[5m])) / 1000 * ` +
+    `(scalar(avg_over_time(energy_price_SEK_per_kWh{area="SE4"}[5m])) + ${POOL_COST_FEES}) * ${POOL_COST_VAT}` +
+    `)[$__interval:5m]) * 5 / 60`;
+
+  const poolCostDaily = new TimeseriesBuilder()
+    .title('Pool kostnad per dag')
+    .description(
+      'Daglig elkostnad för pool-cirkulationspumpen och värmepumpen. ' +
+      'Beräknas som energi × spotpris (SE4) + nätavgift + energiskatt + moms 25%, ' +
+      'samma formel som pool-pump-planner använder.'
+    )
+    .datasource(VM_DS)
+    .unit('currencySEK')
+    .drawStyle('bars' as any)
+    .fillOpacity(100)
+    .axisSoftMin(0)
+    .interval('1d')
+    .colorScheme(paletteColor())
+    .thresholds(greenThreshold())
+    .legend(legendBottom())
+    .tooltip(tooltipMulti())
+    .insertNulls(86_400_000)
+    .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
+    .overrides([
+      overrideDisplayAndColor('pool_iqpump_motordata_power', 'Cirkulationspump', 'blue'),
+      overrideDisplayAndColor('aqua_temp_power_usage', 'Värmepump', 'red'),
+    ])
+    .withTarget(vmExpr('A', poolCostExpr('pool_iqpump_motordata_power'), 'pool_iqpump_motordata_power'))
+    .withTarget(vmExpr('B', poolCostExpr('aqua_temp_power_usage'), 'aqua_temp_power_usage'))
+    .timeFrom('now/y')
+    .gridPos({ h: 8, w: 16, x: 0, y: 60 });
+
+  // Pool kostnad i år (stat) — accumulated YTD cost across both pumps.
+  // sum() drops labels so the two metrics with disjoint label sets can be
+  // added; `or vector(0)` handles the period before aqua_temp_power_usage
+  // started emitting (April 2026). 15m subquery step keeps the YTD point
+  // count under VM's per-series limit while still capturing pump-cycle
+  // dynamics; spot price is hourly so 15m is plenty for the price factor.
+  const poolCostYTD = new StatBuilder()
+    .title('Pool kostnad i år')
+    .description(
+      'Ackumulerad elkostnad för poolen sedan årsskiftet. ' +
+      'Inkluderar cirkulationspump + värmepump × spotpris (SE4) + nätavgift + energiskatt + moms 25%.'
+    )
+    .datasource(VM_DS)
+    .unit('currencySEK')
+    .thresholds(greenThreshold())
+    .withTarget(vmExpr(
+      'A',
+      'sum_over_time((' +
+        '((sum(avg_over_time(pool_iqpump_motordata_power[15m])) or vector(0)) + ' +
+        '(sum(avg_over_time(aqua_temp_power_usage[15m])) or vector(0))) / 1000 * ' +
+        `(scalar(avg_over_time(energy_price_SEK_per_kWh{area="SE4"}[15m])) + ${POOL_COST_FEES}) * ${POOL_COST_VAT}` +
+      ')[$__range:15m]) * 15 / 60',
+      'YTD',
+    ))
+    .timeFrom('now/y')
+    .gridPos({ h: 8, w: 8, x: 16, y: 60 });
+
   // Smart Planner — 30-day planned-vs-slack hours. Split out from the cost
   // panel so the two unit families (SEK / hours) don't fight over a shared
   // axis. Planned = hours the planner committed to running; slack = hours
@@ -234,5 +305,5 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .timeFrom('14d/d')
     .gridPos({ h: 8, w: 12, x: 12, y: 44 });
 
-  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, deltaT, pumpPlanHours, pumpPlan, pumpPlanCost];
+  return [waterTemp, poolTempStat, heatPump, pumpSpeedStat, pumpSpeedTs, deltaT, pumpPlanHours, pumpPlan, pumpPlanCost, poolCostDaily, poolCostYTD];
 }

--- a/grafana/src/panels/spa.ts
+++ b/grafana/src/panels/spa.ts
@@ -31,7 +31,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
     ])
     .withTarget(vmMetric('A', 'spa_climate', 'current_temperature_value'))
     .withTarget(vmExpr('B', 'last_over_time(spa_temperature_range_state_text[$__interval])', 'state_text'))
-    .gridPos({ h: 8, w: 12, x: 0, y: 61 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 69 });
 
   // Spabadet (stat) - latest temp
   const spaStat = new StatBuilder()
@@ -43,7 +43,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
       overrideDisplayAndColor('current_temperature_value', 'Temperatur', 'purple'),
     ])
     .withTarget(vmMetric('A', 'spa_climate', 'current_temperature_value'))
-    .gridPos({ h: 8, w: 4, x: 12, y: 61 });
+    .gridPos({ h: 8, w: 4, x: 12, y: 69 });
 
   // Spa Circulation (gauge)
   const spaCirculation = new GaugeBuilder()
@@ -59,7 +59,7 @@ export function spaPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('A', 'last_over_time(spa_circulation_pump_value[$__interval])', 'circulation'))
     .withTarget(vmMetric('B', 'spa_pump_1', 'value'))
     .withTarget(vmMetric('C', 'spa_pump_2', 'value'))
-    .gridPos({ h: 8, w: 8, x: 16, y: 61 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 69 });
 
   return [spaTs, spaStat, spaCirculation];
 }

--- a/grafana/src/panels/system.ts
+++ b/grafana/src/panels/system.ts
@@ -44,7 +44,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('Power', 'last_over_time(ha_wallbox_pulsar_max_sn_992144_charging_power_value[$__interval]) * 1000', 'Laddning'),
     )
-    .gridPos({ h: 8, w: 12, x: 0, y: 136 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 144 });
 
   // ⚡ Urladdningsgräns (stat, current discharge limit in W)
   const dischargeLimitStat = new StatBuilder()
@@ -59,7 +59,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('A', 'last_over_time(sum(sigenergy_ems_control_max_discharge_limit_w[$__interval]) by ())'),
     )
-    .gridPos({ h: 8, w: 4, x: 12, y: 136 });
+    .gridPos({ h: 8, w: 4, x: 12, y: 144 });
 
   // 💾 Senaste VM-backup (stat, age in seconds)
   const vmBackup = new StatBuilder()
@@ -75,7 +75,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('A', 'now() - last_over_time(vm_backup_last_success_timestamp[$__interval])'),
     )
-    .gridPos({ h: 8, w: 8, x: 16, y: 136 });
+    .gridPos({ h: 8, w: 8, x: 16, y: 144 });
 
   // ⏱ Poll-tid Sigenergy (timeseries, duration_ms per poll cycle)
   const pollDuration = new TimeseriesBuilder()
@@ -91,7 +91,7 @@ export function systemPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(
       vmExpr('Duration', 'last_over_time(sigenergy_bridge_duration_ms[$__interval])', 'Duration (ms)'),
     )
-    .gridPos({ h: 8, w: 24, x: 0, y: 144 });
+    .gridPos({ h: 8, w: 24, x: 0, y: 152 });
 
   return [dischargeControl, dischargeLimitStat, vmBackup, pollDuration];
 }

--- a/grafana/src/panels/volvo.ts
+++ b/grafana/src/panels/volvo.ts
@@ -33,7 +33,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .withTarget(vmExpr('B', 'last_over_time(ha_xc40_state_of_charge[$__interval])', 'soc'))
     .withTarget(vmExpr('C', 'last_over_time(ha_xc40_target_state_of_charge[$__interval])', 'target_soc'))
     .withTarget(vmExpr('D', 'last_over_time(ha_volvo_xc40_target_battery_charge_level_value[$__interval])', 'target_charge'))
-    .gridPos({ h: 8, w: 12, x: 0, y: 101 });
+    .gridPos({ h: 8, w: 12, x: 0, y: 109 });
 
   // ⚡ XC40 Laddeffekt (timeseries) - charging power
   const chargingTs = new TimeseriesBuilder()
@@ -47,7 +47,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
     .tooltip(tooltipMulti())
     .insertNulls(SPAN_NULLS_MS)
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_charging_power_value[$__interval])', 'Laddeffekt'))
-    .gridPos({ h: 8, w: 6, x: 12, y: 101 });
+    .gridPos({ h: 8, w: 6, x: 12, y: 109 });
 
   // 🛣️ Räckvidd (stat) - distance to empty battery
   const distanceStat = new StatBuilder()
@@ -62,7 +62,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 100 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_distance_to_empty_battery_value[$__interval])', 'Räckvidd'))
-    .gridPos({ h: 8, w: 3, x: 18, y: 101 });
+    .gridPos({ h: 8, w: 3, x: 18, y: 109 });
 
   // 🔧 Service (stat) - time to service
   const serviceStat = new StatBuilder()
@@ -76,7 +76,7 @@ export function volvoPanels(): cog.Builder<dashboard.Panel>[] {
       { color: 'green', value: 90 },
     ]))
     .withTarget(vmExpr('A', 'last_over_time(ha_volvo_xc40_time_to_service_value[$__interval])', 'Service'))
-    .gridPos({ h: 8, w: 3, x: 21, y: 101 });
+    .gridPos({ h: 8, w: 3, x: 21, y: 109 });
 
   return [batteryTs, chargingTs, distanceStat, serviceStat];
 }


### PR DESCRIPTION
## Summary

Adds two new panels under the **Poolen** row that track the actual SEK cost of running the pool circulation pump and heat pump, using SE4 spot price + Swedish grid + tax loading.

- **Pool kostnad per dag** — stacked daily bars from Jan 1 onward, one series per pump (Cirkulationspump in blue, Värmepump in red).
- **Pool kostnad i år** — stat showing accumulated YTD cost across both pumps. Currently reads ~504 kr.

Both anchor to start-of-year via `timeFrom: now/y` ("This year so far").

## Pricing formula

Matches `pool-pump-planner/config.go` defaults (calibrated to the March 2026 E.ON invoice for SE4/MMO Malmö):

```
(spot_SE4 + 0.2584 transferfee + 0.36 energiskatt) × 1.25 VAT
```

Inner `sum()` wrapper collapses incidental label variants (e.g. a stray `pool_iqpump_motordata_power{device="00"}` series with one sample over YTD) so each pump shows up as a single legend entry rather than duplicating "Cirkulationspump".

## Layout

To make room in the Poolen row, all rows below have been shifted down by 8 grid units (Spabadet → 68, Energi → 77, Volvo XC40 → 108, Navimow → 117, Eufy Cameras → 126, Tapo → 135, System → 143). The dashboard test (`each panel y value falls within its row bounds`) still passes.

## Subquery step trade-off

- Daily timeseries uses `[$__interval:5m]` — 5-min step covers the heat pump's 5-min scrape interval.
- YTD stat uses `[$__range:15m]` — coarser step keeps the YTD point count under VictoriaMetrics' per-series limit. Spot price is hourly so 15m is plenty for the price factor; pump cycles are 15m+ so accuracy holds.

## Test plan

**Local (pre-merge):**
- [x] `cd grafana && npm test` — all 5 tests pass (rule identity, refIds, UID uniqueness, panel y bounds, alert grouping).
- [x] `cd grafana && npm run build` — dashboard.json + alerts.json regenerate without errors.
- [x] PromQL formulas validated against VictoriaMetrics directly via `scripts/vm-query.sh`:
  - Per-day circulation pump cost ranges 0.5–5 SEK (matches expectation).
  - Per-day heat pump cost is 0 before May 3, then 2→27 SEK as it ramped up (matches first-run timing).
  - YTD combined: ~504 SEK.

**Post-merge E2E:**
- [x] `npm run generate` — dashboard uploaded to Grafana cloud (version 111).
- [x] Open https://irisgatan.grafana.net/d/irisgatan-v3 — both panels render with "This year so far" override; legend shows two entries (no duplicate "Cirkulationspump"); Spabadet/Energi rows below appear correctly after the row shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)