### PR TITLE
feat(mcp): add Home Assistant MCP server

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,6 @@
 # https://dashboard.balena-cloud.com/preferences/access-tokens
 BALENA_TOKEN=
+
+# Home Assistant MCP server (.mcp.json) — set in .env or ~/.zshrc
+HOMEASSISTANT_URL=
+HOMEASSISTANT_TOKEN=

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "Home Assistant": {
+      "command": "uvx",
+      "args": ["ha-mcp@latest"],
+      "env": {
+        "HOMEASSISTANT_URL": "${HOMEASSISTANT_URL}",
+        "HOMEASSISTANT_TOKEN": "${HOMEASSISTANT_TOKEN}"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "Home Assistant": {
       "command": "uvx",
-      "args": ["ha-mcp@latest"],
+      "args": ["ha-mcp==7.6.0"],
       "env": {
         "HOMEASSISTANT_URL": "${HOMEASSISTANT_URL}",
         "HOMEASSISTANT_TOKEN": "${HOMEASSISTANT_TOKEN}"

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "Home Assistant": {
       "command": "uvx",
-      "args": ["ha-mcp==7.6.0"],
+      "args": [
+        "--from",
+        "git+https://github.com/homeassistant-ai/ha-mcp@be864b5d685f167334487d4fe83324afbb4999ca",
+        "ha-mcp"
+      ],
       "env": {
         "HOMEASSISTANT_URL": "${HOMEASSISTANT_URL}",
         "HOMEASSISTANT_TOKEN": "${HOMEASSISTANT_TOKEN}"


### PR DESCRIPTION
## Summary
- Adds project-scoped `.mcp.json` registering `ha-mcp@latest` (via `uvx`) as the **Home Assistant** MCP server.
- Credentials are referenced via `${HOMEASSISTANT_URL}` / `${HOMEASSISTANT_TOKEN}` shell expansion — **no secrets in the repo**. Set them in `~/.zshrc` or local `.env`.
- Documents both vars in `.env.template`.

## Test plan
- [ ] Set `HOMEASSISTANT_URL` and `HOMEASSISTANT_TOKEN` locally (zshrc or `.env`).
- [ ] Restart Claude Code in the project; approve the new project-scoped MCP on first prompt.
- [ ] Confirm the **Home Assistant** server appears in `/mcp` and tools are listed.