### PR TITLE
feat(victoria-metrics): scrape WUD prometheus metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,13 @@ services:
     # No ports exposed - only accessible via database-auth (vmauth) for security
     volumes:
       - victoria-metrics:/victoria-metrics-data
+      - ./victoria-metrics/vmscrape.yml:/etc/vmscrape.yml:ro
     command:
       - -storageDataPath=/victoria-metrics-data
       - -retentionPeriod=3y
       - -httpListenAddr=:8181
       - -dedup.minScrapeInterval=10s
+      - -promscrape.config=/etc/vmscrape.yml
 
   database-auth:
     image: victoriametrics/vmauth:latest

--- a/victoria-metrics/vmscrape.yml
+++ b/victoria-metrics/vmscrape.yml
@@ -1,0 +1,8 @@
+# VictoriaMetrics native scrape config (-promscrape.config).
+# Targets are resolved via docker DNS on the iot-fetcher_default network.
+scrape_configs:
+  - job_name: 'wud'
+    scrape_interval: 60s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['wud:3000']


### PR DESCRIPTION
## What

Enable VictoriaMetrics' built-in scraper (`-promscrape.config`) to pull WUD's Prometheus `/metrics` endpoint. No separate Prometheus/vmagent process needed — single-node VM scrapes natively.

## Changes
- `docker-compose.yml` — append `-promscrape.config=/etc/vmscrape.yml` to the `database` (VM) command (existing flags untouched) and mount the scrape file.
- `victoria-metrics/vmscrape.yml` — new scrape job targeting `wud:3000` (resolves via docker DNS on `iot-fetcher_default`), 60s interval.

## Notes
- WUD serves `/metrics` on :3000 by default (`WUD_PROMETHEUS_ENABLED=true`), so the `wud` service needs no changes.
- Surfaces `wud_containers`, `wud_registry_response`, `wud_trigger_count`, `wud_watcher_total`.

## Test plan
- [ ] On rpi5: `docker compose ... up -d database`, then `vmui` Targets shows `wud` job **up**.
- [ ] Query `wud_containers` returns series in VM/Grafana.