### PR TITLE
webui: show pool pump RPM without decimals

### DIFF
--- a/fetcher-core/webui/app/lib/values.ts
+++ b/fetcher-core/webui/app/lib/values.ts
@@ -11,7 +11,7 @@ export const values: Config = [
     [
         { measurement: 'spa_climate', field: 'current_temperature_value', title: '🛁 Spa Temperatur', unit: '°C', sparkline: '24h', sparklineMin: 0, sparklineMax: 45 },
         { measurement: 'pool_temperature', field: 'value', title: '🏊 Pool Temperatur', unit: '°C', sparkline: '24h', sparklineMin: 0, sparklineMax: 30 },
-        { measurement: 'pool_iqpump_motordata', field: 'speed', title: '💦 Poolpump', unit: 'RPM', sparkline: '24h', sparklineMin: 0, sparklineMax: 3000 },
+        { measurement: 'pool_iqpump_motordata', field: 'speed', title: '💦 Poolpump', unit: 'RPM', decimals: 0, sparkline: '24h', sparklineMin: 0, sparklineMax: 3000 },
     ],
     [
         { measurement: 'tibber', field: 'accumulatedCost', title: 'Dygnskostnad', unit: 'Kr', decimals: 0, sparkline: '24h', sparklineMin: 0 },

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -123,7 +123,6 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .title('Pumpvarvtal')
     .datasource(VM_DS)
     .unit('rotrpm')
-    .decimals(0)
     .min(0)
     .max(3600)
     .thresholds(thresholds([{ color: 'blue', value: null }]))

--- a/grafana/src/panels/pool.ts
+++ b/grafana/src/panels/pool.ts
@@ -123,6 +123,7 @@ export function poolPanels(): cog.Builder<dashboard.Panel>[] {
     .title('Pumpvarvtal')
     .datasource(VM_DS)
     .unit('rotrpm')
+    .decimals(0)
     .min(0)
     .max(3600)
     .thresholds(thresholds([{ color: 'blue', value: null }]))


### PR DESCRIPTION
## What

Set `decimals: 0` on the **💦 Poolpump** tile in the webui (`fetcher-core/webui/app/lib/values.ts`) so the pump speed (RPM) renders as a whole number.

## Why

The Poolpump tile (`pool_iqpump_motordata` / `speed`) had no `decimals` set. `LatestValue` defaults to `decimals = 1` and renders `value.toFixed(decimals)`, so RPM showed one decimal place (e.g. `2950.0 RPM`). RPM is naturally a whole number; `decimals: 0` matches the other whole-number tiles (battery %, kostnad, etc.).

## Note

An earlier revision of this PR touched the Grafana dashboard panel instead. That change has been reverted — the request targeted the **webui** dashboard, so the final diff is a single one-line change to `values.ts`.

https://claude.ai/code/session_013gzD8BigJHpsDGEJTMizv2

---
_Generated by [Claude Code](https://claude.ai/code/session_013gzD8BigJHpsDGEJTMizv2)_