### PR TITLE
feat(webui): 7-day YR weather row on dashboard

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "webui",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "--prefix", "fetcher-core/webui", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-06-weather-row.md
+++ b/docs/superpowers/plans/2026-07-06-weather-row.md
@@ -1,0 +1,524 @@
+# 7-Day Weather Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a row of 7 daily weather boxes (icon + hi/lo + weekday) above the energy price bar on the iPad dashboard, sourced from YR / MET Norway.
+
+**Architecture:** A pure aggregation function turns the MET Locationforecast timeseries into 7 daily summaries. A cached Next.js API route (`/api/weather`) fetches MET server-side and calls that function. A client `WeatherBar` component renders the boxes and is wired into the dashboard page above `<EnergyPriceBar />`.
+
+**Tech Stack:** Next.js 15 (App Router), React 18, TypeScript, Tailwind. New devDep: `vitest` (for the pure aggregation unit only). No runtime deps added. Weather icons fetched at runtime from jsDelivr CDN.
+
+## Global Constraints
+
+- All work is under `fetcher-core/webui/`. Run commands from that directory.
+- Location is env-configurable, read server-side only: `WEATHER_LAT` (default `55.571`), `WEATHER_LON` (default `12.997`), `WEATHER_ALTITUDE` (default `19`). Defaults = Kulladal, Malmö.
+- MET API requires an identifying `User-Agent`: `iot-fetcher-weather/1.0 github.com/tkhduracell/iot-fetcher`.
+- Forecast API: `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat={lat}&lon={lon}&altitude={alt}`.
+- Icon CDN: `https://cdn.jsdelivr.net/gh/metno/weathericons/weather/svg/{symbolCode}.svg`.
+- Timezone for day-grouping and weekday labels: `Europe/Stockholm`. Use native `Intl` — do NOT add a date-lib dependency.
+- UI copy is Swedish, matching `EnergyPriceBar.tsx`.
+- Follow existing conventions: `process.env.X || 'default'` in routes (see `app/api/sonos/[...path]/route.ts`), Tailwind wrapper idiom from `EnergyPriceBar.tsx`.
+
+---
+
+## File Structure
+
+- Create `app/lib/weather.ts` — types + `aggregateDailyForecast()` pure function.
+- Create `app/lib/weather.test.ts` — vitest unit tests for the aggregation.
+- Create `app/api/weather/route.ts` — cached GET route: env → MET fetch → aggregate → JSON.
+- Create `app/components/WeatherBar.tsx` — client component rendering the 7 boxes.
+- Modify `app/page.tsx` — insert `<WeatherBar />` above `<EnergyPriceBar />`.
+- Modify `package.json` — add `vitest` devDep + `test` script.
+
+---
+
+## Task 1: Aggregation function + tests
+
+**Files:**
+- Create: `fetcher-core/webui/app/lib/weather.ts`
+- Test: `fetcher-core/webui/app/lib/weather.test.ts`
+- Modify: `fetcher-core/webui/package.json` (add `vitest` devDep + `test` script)
+
+**Interfaces:**
+- Consumes: nothing (pure, stdlib only).
+- Produces:
+  - `interface MetTimeseriesEntry { time: string; data: { instant: { details: { air_temperature?: number } }; next_1_hours?: { summary: { symbol_code: string } }; next_6_hours?: { summary: { symbol_code: string } }; next_12_hours?: { summary: { symbol_code: string } } } }`
+  - `interface DailyForecast { date: string; symbolCode: string; tempMax: number | null; tempMin: number | null }`
+  - `function aggregateDailyForecast(timeseries: MetTimeseriesEntry[], opts?: { timeZone?: string; days?: number }): DailyForecast[]`
+
+- [ ] **Step 1: Add vitest devDep and test script**
+
+Run:
+```bash
+cd fetcher-core/webui
+npm install --save-dev vitest@^2
+```
+Then edit `package.json` `scripts` to add (keep existing entries):
+```json
+    "test": "vitest run"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/lib/weather.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { aggregateDailyForecast, MetTimeseriesEntry } from './weather';
+
+// Helper: build a minimal timeseries entry.
+function entry(
+  time: string,
+  temp: number,
+  next6?: string,
+  next1?: string,
+): MetTimeseriesEntry {
+  return {
+    time,
+    data: {
+      instant: { details: { air_temperature: temp } },
+      ...(next6 ? { next_6_hours: { summary: { symbol_code: next6 } } } : {}),
+      ...(next1 ? { next_1_hours: { summary: { symbol_code: next1 } } } : {}),
+    },
+  };
+}
+
+describe('aggregateDailyForecast', () => {
+  it('groups timesteps by Europe/Stockholm calendar day (summer +02:00)', () => {
+    // 2026-07-06T22:30Z is 2026-07-07 00:30 local, so it belongs to the 7th.
+    const ts = [
+      entry('2026-07-06T10:00:00Z', 20, 'clearsky_day'),
+      entry('2026-07-06T22:30:00Z', 15, 'clearsky_night'),
+    ];
+    const days = aggregateDailyForecast(ts);
+    expect(days.map(d => d.date)).toEqual(['2026-07-06', '2026-07-07']);
+  });
+
+  it('computes rounded daily max/min from instant air_temperature', () => {
+    const ts = [
+      entry('2026-07-06T06:00:00Z', 12.4, 'clearsky_day'),
+      entry('2026-07-06T10:00:00Z', 21.6, 'clearsky_day'),
+      entry('2026-07-06T16:00:00Z', 18.2, 'cloudy'),
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.tempMax).toBe(22);
+    expect(day.tempMin).toBe(12);
+  });
+
+  it('picks the symbol of the timestep nearest 12:00 local, preferring next_6_hours', () => {
+    // Local noon in summer = 10:00Z. Middle entry wins.
+    const ts = [
+      entry('2026-07-06T06:00:00Z', 12, 'clearsky_day'),   // 08 local
+      entry('2026-07-06T10:00:00Z', 20, 'rain', 'fog'),    // 12 local -> next_6 'rain'
+      entry('2026-07-06T16:00:00Z', 18, 'cloudy'),         // 18 local
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.symbolCode).toBe('rain');
+  });
+
+  it('falls back to next_1_hours when next_6_hours is absent on the midday step', () => {
+    const ts = [
+      entry('2026-07-06T10:00:00Z', 20, undefined, 'lightrain'), // 12 local, only next_1
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.symbolCode).toBe('lightrain');
+  });
+
+  it('returns at most `days` days', () => {
+    const ts = Array.from({ length: 10 }, (_, i) =>
+      entry(`2026-07-${String(6 + i).padStart(2, '0')}T10:00:00Z`, 20, 'clearsky_day'),
+    );
+    expect(aggregateDailyForecast(ts, { days: 7 })).toHaveLength(7);
+  });
+
+  it('returns null temps when a day has no air_temperature', () => {
+    const ts: MetTimeseriesEntry[] = [
+      { time: '2026-07-06T10:00:00Z', data: { instant: { details: {} }, next_6_hours: { summary: { symbol_code: 'cloudy' } } } },
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.tempMax).toBeNull();
+    expect(day.tempMin).toBeNull();
+    expect(day.symbolCode).toBe('cloudy');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module './weather'` / `aggregateDailyForecast is not a function`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `app/lib/weather.ts`:
+```ts
+export interface MetTimeseriesEntry {
+  time: string;
+  data: {
+    instant: { details: { air_temperature?: number } };
+    next_1_hours?: { summary: { symbol_code: string } };
+    next_6_hours?: { summary: { symbol_code: string } };
+    next_12_hours?: { summary: { symbol_code: string } };
+  };
+}
+
+export interface DailyForecast {
+  date: string; // YYYY-MM-DD in the configured timezone
+  symbolCode: string; // '' when no symbol is available for the day
+  tempMax: number | null;
+  tempMin: number | null;
+}
+
+const DEFAULT_TZ = 'Europe/Stockholm';
+
+// 'YYYY-MM-DD' for the given ISO instant in `tz`. en-CA gives ISO-ordered parts.
+function localDay(iso: string, tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(iso));
+}
+
+// Local hour-of-day (0-23) for the given ISO instant in `tz`.
+function localHour(iso: string, tz: string): number {
+  const h = new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    hour: '2-digit',
+    hour12: false,
+  }).format(new Date(iso));
+  // en-GB can yield '24' for midnight in some engines; normalise to 0.
+  return parseInt(h, 10) % 24;
+}
+
+function symbolOf(e: MetTimeseriesEntry): string | undefined {
+  return (
+    e.data.next_6_hours?.summary.symbol_code ??
+    e.data.next_1_hours?.summary.symbol_code ??
+    e.data.next_12_hours?.summary.symbol_code
+  );
+}
+
+export function aggregateDailyForecast(
+  timeseries: MetTimeseriesEntry[],
+  opts: { timeZone?: string; days?: number } = {},
+): DailyForecast[] {
+  const tz = opts.timeZone ?? DEFAULT_TZ;
+  const maxDays = opts.days ?? 7;
+
+  // Group entries by local day, preserving first-seen day order.
+  const byDay = new Map<string, MetTimeseriesEntry[]>();
+  for (const e of timeseries) {
+    const day = localDay(e.time, tz);
+    const bucket = byDay.get(day);
+    if (bucket) bucket.push(e);
+    else byDay.set(day, [e]);
+  }
+
+  const days: DailyForecast[] = [];
+  for (const [date, entries] of byDay) {
+    if (days.length >= maxDays) break;
+
+    const temps = entries
+      .map(e => e.data.instant.details.air_temperature)
+      .filter((t): t is number => typeof t === 'number');
+    const tempMax = temps.length ? Math.round(Math.max(...temps)) : null;
+    const tempMin = temps.length ? Math.round(Math.min(...temps)) : null;
+
+    // Symbol from the entry nearest 12:00 local that actually has a symbol.
+    const ranked = [...entries].sort(
+      (a, b) =>
+        Math.abs(localHour(a.time, tz) - 12) - Math.abs(localHour(b.time, tz) - 12),
+    );
+    let symbolCode = '';
+    for (const e of ranked) {
+      const s = symbolOf(e);
+      if (s) {
+        symbolCode = s;
+        break;
+      }
+    }
+
+    days.push({ date, symbolCode, tempMax, tempMin });
+  }
+
+  return days;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: PASS — 6 passing tests.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add fetcher-core/webui/app/lib/weather.ts fetcher-core/webui/app/lib/weather.test.ts fetcher-core/webui/package.json fetcher-core/webui/package-lock.json
+git commit -m "feat(webui): add MET forecast daily-aggregation helper"
+```
+
+---
+
+## Task 2: `/api/weather` route
+
+**Files:**
+- Create: `fetcher-core/webui/app/api/weather/route.ts`
+
+**Interfaces:**
+- Consumes: `aggregateDailyForecast`, `MetTimeseriesEntry`, `DailyForecast` from `../../lib/weather`.
+- Produces: `GET` returns `{ days: DailyForecast[] }` on success, or `{ error: string }` with a non-200 status on failure.
+
+- [ ] **Step 1: Write the route**
+
+Create `app/api/weather/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { aggregateDailyForecast, MetTimeseriesEntry } from '../../lib/weather';
+
+const USER_AGENT = 'iot-fetcher-weather/1.0 github.com/tkhduracell/iot-fetcher';
+
+export async function GET() {
+  const lat = process.env.WEATHER_LAT || '55.571';
+  const lon = process.env.WEATHER_LON || '12.997';
+  const altitude = process.env.WEATHER_ALTITUDE || '19';
+
+  const params = new URLSearchParams({ lat, lon });
+  if (altitude) params.set('altitude', altitude);
+  const url = `https://api.met.no/weatherapi/locationforecast/2.0/compact?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      // Cache server-side ~30 min: respects MET TOS and survives the hourly
+      // full-page reload without re-hitting MET.
+      next: { revalidate: 1800 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `MET request failed: ${res.status}` },
+        { status: 502 },
+      );
+    }
+
+    const body = await res.json();
+    const timeseries: MetTimeseriesEntry[] = body?.properties?.timeseries ?? [];
+    const days = aggregateDailyForecast(timeseries, { days: 7 });
+    return NextResponse.json({ days });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Manually verify the route against the dev server**
+
+Run (in one terminal): `npm run dev`
+Then (in another):
+```bash
+curl -s http://localhost:3000/api/weather | python3 -m json.tool | head -40
+```
+Expected: JSON `{ "days": [ { "date": "YYYY-MM-DD", "symbolCode": "...", "tempMax": N, "tempMin": N }, ... ] }` with 7 entries, dates starting today, plausible temps, non-empty symbolCodes.
+
+Also verify env override:
+```bash
+WEATHER_LAT=57.7089 WEATHER_LON=11.9746 WEATHER_ALTITUDE=12 npm run dev
+# then curl again — dates/temps should reflect Göteborg
+```
+Stop the dev server when done (Ctrl-C).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fetcher-core/webui/app/api/weather/route.ts
+git commit -m "feat(webui): add cached /api/weather MET forecast route"
+```
+
+---
+
+## Task 3: `WeatherBar` component
+
+**Files:**
+- Create: `fetcher-core/webui/app/components/WeatherBar.tsx`
+
+**Interfaces:**
+- Consumes: `DailyForecast` type from `../lib/weather`; the `/api/weather` route from Task 2.
+- Produces: default-exported React component `WeatherBar` (no props).
+
+- [ ] **Step 1: Write the component**
+
+Create `app/components/WeatherBar.tsx`:
+```tsx
+import React, { useEffect, useState } from 'react';
+import { DailyForecast } from '../lib/weather';
+
+const ICON_BASE =
+  'https://cdn.jsdelivr.net/gh/metno/weathericons/weather/svg';
+
+const Wrapper = (props: { children: React.ReactNode }) => (
+  <div className="px-1.5 py-1 rounded-md bg-sky-100 dark:bg-sky-900 shadow-sm ring-1 ring-sky-200 dark:ring-sky-800 flex items-center justify-center">
+    {props.children}
+  </div>
+);
+
+// Swedish short weekday for a YYYY-MM-DD date; anchored to noon local so the
+// date can't drift across the timezone boundary.
+function weekdayLabel(date: string): string {
+  const d = new Date(`${date}T12:00:00`);
+  return new Intl.DateTimeFormat('sv-SE', {
+    weekday: 'short',
+    timeZone: 'Europe/Stockholm',
+  }).format(d);
+}
+
+const WeatherBar: React.FC = () => {
+  const [days, setDays] = useState<DailyForecast[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/weather')
+      .then(async res => {
+        const body = await res.json();
+        if (!res.ok) throw new Error(body?.error || `HTTP ${res.status}`);
+        return body.days as DailyForecast[];
+      })
+      .then(d => {
+        if (!cancelled) setDays(d);
+      })
+      .catch(e => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'okänt fel');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) return <Wrapper>Fel uppstod vid laddning: {error}</Wrapper>;
+  if (!days) return <Wrapper>Hämtar väder…</Wrapper>;
+  if (days.length === 0) return <Wrapper>Ingen väderprognos tillgänglig.</Wrapper>;
+
+  return (
+    <Wrapper>
+      <div className="w-full flex flex-row gap-1">
+        {days.map((day, idx) => (
+          <div
+            key={day.date}
+            className="flex-1 flex flex-col items-center justify-between gap-0.5 rounded bg-sky-200/50 dark:bg-sky-800/40 py-1"
+          >
+            <div className="text-xs font-semibold capitalize text-gray-700 dark:text-gray-200">
+              {idx === 0 ? 'Idag' : weekdayLabel(day.date)}
+            </div>
+            {day.symbolCode ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={`${ICON_BASE}/${day.symbolCode}.svg`}
+                alt={day.symbolCode}
+                className="w-10 h-10"
+                loading="eager"
+              />
+            ) : (
+              <div className="w-10 h-10" />
+            )}
+            <div className="text-xs text-gray-700 dark:text-gray-200">
+              <span className="font-semibold">
+                {day.tempMax != null ? `${day.tempMax}°` : '–'}
+              </span>
+              <span className="mx-0.5 text-gray-400">/</span>
+              <span className="text-gray-500 dark:text-gray-400">
+                {day.tempMin != null ? `${day.tempMin}°` : '–'}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Wrapper>
+  );
+};
+
+export default WeatherBar;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add fetcher-core/webui/app/components/WeatherBar.tsx
+git commit -m "feat(webui): add WeatherBar 7-day forecast component"
+```
+
+---
+
+## Task 4: Wire into the dashboard
+
+**Files:**
+- Modify: `fetcher-core/webui/app/page.tsx`
+
+**Interfaces:**
+- Consumes: `WeatherBar` default export from `./components/WeatherBar`.
+- Produces: nothing (final wiring).
+
+- [ ] **Step 1: Import WeatherBar**
+
+In `app/page.tsx`, add alongside the other component imports (after the `EnergyPriceBar` import on line 11):
+```tsx
+import WeatherBar from './components/WeatherBar';
+```
+
+- [ ] **Step 2: Render it above the energy bar**
+
+In the JSX, change:
+```tsx
+        <Grid values={values} onOpen={openFullscreen} />
+        <EnergyPriceBar />
+```
+to:
+```tsx
+        <Grid values={values} onOpen={openFullscreen} />
+        <WeatherBar />
+        <EnergyPriceBar />
+```
+
+- [ ] **Step 3: Typecheck and build**
+
+Run:
+```bash
+npm run typecheck
+npm run build
+```
+Expected: typecheck clean; build succeeds (an ESLint warning is acceptable, an error is not).
+
+- [ ] **Step 4: Manual browser verification**
+
+Run: `npm run dev`, open `http://localhost:3000`.
+Expected: a row of 7 boxes sits directly above the energy price bar. Each box shows a Swedish weekday (first = "Idag"), a MET weather icon, and `max° / min°`. Icons load from the CDN. Resize toward iPad width — boxes stay evenly sized and readable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fetcher-core/webui/app/page.tsx
+git commit -m "feat(webui): show 7-day weather row above energy price bar"
+```
+
+---
+
+## Post-merge E2E (rpi5)
+
+- Optionally set `WEATHER_LAT` / `WEATHER_LON` / `WEATHER_ALTITUDE` in `fetcher-core/webui/.env` (defaults already = Kulladal). Build the image (`make build`, push to registry — not on rpi5) and redeploy with both compose files. Confirm the iPad dashboard shows the weather row and that it survives the hourly auto-reload.
+```

--- a/docs/superpowers/specs/2026-07-06-weather-row-design.md
+++ b/docs/superpowers/specs/2026-07-06-weather-row-design.md
@@ -1,0 +1,118 @@
+# 7-Day Weather Row — Design
+
+**Date:** 2026-07-06
+**Component:** `fetcher-core/webui` (Next.js dashboard shown on iPad kiosk)
+
+## Goal
+
+Add a row of 7 boxes (one per day) showing the weather forecast, placed
+directly **above** the `EnergyPriceBar`. Each box shows a pretty weather icon,
+the daily high/low temperature, and a weekday label. Data comes from **YR / MET
+Norway** (easiest free API — no key, JSON, returns a `symbol_code` per timestep
+that maps 1:1 to an open-licensed icon set).
+
+## Data source
+
+- **Forecast API:** MET Norway *Locationforecast 2.0 compact*
+  `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat={lat}&lon={lon}&altitude={alt}`
+  - Requires an identifying `User-Agent` header (MET TOS). We send
+    `iot-fetcher-weather/1.0 github.com/tkhduracell/iot-fetcher`.
+  - Returns `properties.timeseries[]`, each with `time`, `data.instant.details.air_temperature`,
+    and forecast-window summaries (`next_1_hours` / `next_6_hours` / `next_12_hours`)
+    each carrying a `summary.symbol_code` (e.g. `partlycloudy_day`).
+  - Verified: returns ~85 timesteps (hourly for ~2 days, then 6-hourly), covering
+    well beyond 7 days.
+- **Icons:** official MET icon set via jsDelivr CDN (chosen: fetch at runtime):
+  `https://cdn.jsdelivr.net/gh/metno/weathericons/weather/svg/{symbol_code}.svg`
+  - Verified 200 `image/svg+xml` for all sampled codes (clearsky_day/night,
+    cloudy, rain, heavyrainandthunder, snow, sleet, fog, partlycloudy_night,
+    lightrainshowers_day, …). The `{symbol_code}` from the API is used verbatim.
+
+## Configuration (env)
+
+Read server-side in the API route; consumed by the `iot-fetcher` container via
+`fetcher-core/webui/.env` (existing `process.env.X || 'default'` convention).
+
+| Var                | Default   | Meaning                          |
+|--------------------|-----------|----------------------------------|
+| `WEATHER_LAT`      | `55.571`  | Latitude (default: Kulladal, Malmö) |
+| `WEATHER_LON`      | `12.997`  | Longitude                        |
+| `WEATHER_ALTITUDE` | `19`      | Altitude in metres (MET accuracy); omit from URL if unset |
+
+Defaults resolve to **Kulladal, Malmö** (YR location `2-2698885`), matching the
+requested location.
+
+## Component 1 — API route `app/api/weather/route.ts`
+
+`GET` handler:
+
+1. Read `WEATHER_LAT` / `WEATHER_LON` / `WEATHER_ALTITUDE` (with defaults).
+2. `fetch` the Locationforecast compact URL with the `User-Agent` header and
+   `next: { revalidate: 1800 }` (server cache ~30 min — respects MET TOS and
+   means the hourly full-page reload hits cache, not MET).
+3. On non-2xx, return `{ error }` with the upstream status.
+4. **Aggregate** `timeseries[]` into up to 7 daily objects:
+   - Group each timestep by its **Europe/Stockholm calendar day** (derive the
+     local `YYYY-MM-DD` via `Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Stockholm' })`
+     — no new dependency).
+   - Take the first 7 distinct days starting from today (local).
+   - `tempMax` / `tempMin` = max / min of `instant.details.air_temperature`
+     across that day's timesteps (rounded to whole °C for display).
+   - `symbolCode` = the symbol of the timestep **nearest 12:00 local** that day,
+     preferring `next_6_hours` → `next_1_hours` → `next_12_hours`. (Midday gives
+     the representative daytime icon.) If a day has no timestep with a symbol,
+     fall back to the nearest available symbol that day.
+   - The route returns only the ISO `date` (`YYYY-MM-DD`); the weekday label is
+     formatted client-side in component 2.
+5. Respond `{ days: DailyForecast[] }` where
+   `DailyForecast = { date: string; symbolCode: string; tempMax: number; tempMin: number }`.
+
+Edge cases: fewer than 7 usable days → return what exists. Missing temps for a
+day → still return the day with whatever symbol is available and `null` temps;
+component renders "–".
+
+## Component 2 — `app/components/WeatherBar.tsx`
+
+Client component, styled to match `EnergyPriceBar` (shared visual language):
+
+- `Wrapper`: `rounded-md`, light/dark `bg`, `ring-1`, `shadow-sm` (same idiom as
+  EnergyPriceBar's wrapper).
+- Fetch `/api/weather` once on mount (`useEffect` + `fetch`); no polling — the
+  page already reloads hourly via `useAutoReload`, and the route is cached.
+- States (Swedish, matching EnergyPriceBar tone):
+  - loading → "Hämtar väder…"
+  - error → "Fel uppstod vid laddning: {msg}"
+  - empty → "Ingen väderprognos tillgänglig."
+- Success: a `flex flex-row gap-1` of up to 7 `flex-1` boxes. Each box:
+  - **Weekday** label on top: first box = "Idag", otherwise Swedish short day
+    (Mån/Tis/Ons/Tor/Fre/Lör/Sön) via
+    `new Intl.DateTimeFormat('sv-SE', { weekday: 'short', timeZone: 'Europe/Stockholm' })`.
+  - **Icon**: `<img>` with `src` = CDN URL for `symbolCode`, fixed size (e.g.
+    `w-10 h-10`), `alt` = symbolCode. `loading="eager"`.
+  - **Hi/Lo**: `{tempMax}° / {tempMin}°` (max emphasised, min muted), "–" when null.
+
+## Component 3 — Wiring `app/page.tsx`
+
+Insert `<WeatherBar />` immediately before `<EnergyPriceBar />` (page.tsx:53),
+inside the existing `flex flex-col gap-1.5` container so spacing is consistent.
+
+## Non-goals / YAGNI
+
+- No storage in VictoriaMetrics (forecasts aren't timeseries metrics; icons
+  don't fit VM).
+- No per-hour detail, no click-through / fullscreen view for weather.
+- No multi-location support (single configured location).
+- No new npm dependencies (native `Intl` handles TZ + weekday formatting).
+
+## Testing
+
+- **Local (pre-merge):**
+  - Unit: aggregation function — feed a captured Locationforecast JSON fixture,
+    assert 7 days, correct hi/lo, midday symbol selection, TZ day-grouping.
+  - Manual: run `npm run dev`, load dashboard, confirm the weather row renders
+    above the energy bar with icons + temps + Swedish weekdays; confirm
+    `/api/weather` returns cached JSON; test with `WEATHER_LAT/LON` overridden.
+  - Verify error/empty states by pointing at a bad URL / forcing a fetch failure.
+- **Post-merge E2E (rpi5):** set `WEATHER_*` in `fetcher-core/webui/.env` (or leave
+  defaults for Kulladal), redeploy, confirm the iPad dashboard shows the row and
+  it survives the hourly reload.

--- a/fetcher-core/webui/app/api/weather/route.ts
+++ b/fetcher-core/webui/app/api/weather/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { aggregateDailyForecast, MetTimeseriesEntry } from '../../lib/weather';
+
+const USER_AGENT = 'iot-fetcher-weather/1.0 github.com/tkhduracell/iot-fetcher';
+
+export async function GET() {
+  const lat = process.env.WEATHER_LAT || '55.571';
+  const lon = process.env.WEATHER_LON || '12.997';
+  const altitude = process.env.WEATHER_ALTITUDE || '19';
+
+  const params = new URLSearchParams({ lat, lon });
+  if (altitude) params.set('altitude', altitude);
+  const url = `https://api.met.no/weatherapi/locationforecast/2.0/compact?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      // Cache server-side ~30 min: respects MET TOS and survives the hourly
+      // full-page reload without re-hitting MET.
+      next: { revalidate: 1800 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `MET request failed: ${res.status}` },
+        { status: 502 },
+      );
+    }
+
+    const body = await res.json();
+    const timeseries: MetTimeseriesEntry[] = body?.properties?.timeseries ?? [];
+    const days = aggregateDailyForecast(timeseries, { days: 7 });
+    return NextResponse.json({ days });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/fetcher-core/webui/app/components/WeatherBar.tsx
+++ b/fetcher-core/webui/app/components/WeatherBar.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { DailyForecast } from '../lib/weather';
+
+const ICON_BASE =
+  'https://cdn.jsdelivr.net/gh/metno/weathericons/weather/svg';
+
+const Wrapper = (props: { children: React.ReactNode }) => (
+  <div className="px-1.5 py-1 rounded-md bg-sky-100 dark:bg-sky-900 shadow-sm ring-1 ring-sky-200 dark:ring-sky-800 flex items-center justify-center">
+    {props.children}
+  </div>
+);
+
+// Swedish short weekday for a YYYY-MM-DD date; anchored to noon local so the
+// date can't drift across the timezone boundary.
+function weekdayLabel(date: string): string {
+  const d = new Date(`${date}T12:00:00`);
+  return new Intl.DateTimeFormat('sv-SE', {
+    weekday: 'short',
+    timeZone: 'Europe/Stockholm',
+  }).format(d);
+}
+
+const WeatherBar: React.FC = () => {
+  const [days, setDays] = useState<DailyForecast[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/weather')
+      .then(async res => {
+        const body = await res.json();
+        if (!res.ok) throw new Error(body?.error || `HTTP ${res.status}`);
+        return body.days as DailyForecast[];
+      })
+      .then(d => {
+        if (!cancelled) setDays(d);
+      })
+      .catch(e => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'okänt fel');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) return <Wrapper>Fel uppstod vid laddning: {error}</Wrapper>;
+  if (!days) return <Wrapper>Hämtar väder…</Wrapper>;
+  if (days.length === 0) return <Wrapper>Ingen väderprognos tillgänglig.</Wrapper>;
+
+  return (
+    <Wrapper>
+      <div className="w-full flex flex-row gap-1">
+        {days.map((day, idx) => (
+          <div
+            key={day.date}
+            className="flex-1 flex flex-col items-center justify-between gap-0.5 rounded bg-sky-200/50 dark:bg-sky-800/40 py-1"
+          >
+            <div className="text-xs font-semibold capitalize text-gray-700 dark:text-gray-200">
+              {idx === 0 ? 'Idag' : weekdayLabel(day.date)}
+            </div>
+            {day.symbolCode ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={`${ICON_BASE}/${day.symbolCode}.svg`}
+                alt={day.symbolCode}
+                className="w-10 h-10"
+                loading="eager"
+              />
+            ) : (
+              <div className="w-10 h-10" />
+            )}
+            <div className="text-xs text-gray-700 dark:text-gray-200">
+              <span className="font-semibold">
+                {day.tempMax != null ? `${day.tempMax}°` : '–'}
+              </span>
+              <span className="mx-0.5 text-gray-400">/</span>
+              <span className="text-gray-500 dark:text-gray-400">
+                {day.tempMin != null ? `${day.tempMin}°` : '–'}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Wrapper>
+  );
+};
+
+export default WeatherBar;

--- a/fetcher-core/webui/app/lib/weather.test.ts
+++ b/fetcher-core/webui/app/lib/weather.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateDailyForecast, MetTimeseriesEntry } from './weather';
+
+// Helper: build a minimal timeseries entry.
+function entry(
+  time: string,
+  temp: number,
+  next6?: string,
+  next1?: string,
+): MetTimeseriesEntry {
+  return {
+    time,
+    data: {
+      instant: { details: { air_temperature: temp } },
+      ...(next6 ? { next_6_hours: { summary: { symbol_code: next6 } } } : {}),
+      ...(next1 ? { next_1_hours: { summary: { symbol_code: next1 } } } : {}),
+    },
+  };
+}
+
+describe('aggregateDailyForecast', () => {
+  it('groups timesteps by Europe/Stockholm calendar day (summer +02:00)', () => {
+    // 2026-07-06T22:30Z is 2026-07-07 00:30 local, so it belongs to the 7th.
+    const ts = [
+      entry('2026-07-06T10:00:00Z', 20, 'clearsky_day'),
+      entry('2026-07-06T22:30:00Z', 15, 'clearsky_night'),
+    ];
+    const days = aggregateDailyForecast(ts);
+    expect(days.map(d => d.date)).toEqual(['2026-07-06', '2026-07-07']);
+  });
+
+  it('computes rounded daily max/min from instant air_temperature', () => {
+    const ts = [
+      entry('2026-07-06T06:00:00Z', 12.4, 'clearsky_day'),
+      entry('2026-07-06T10:00:00Z', 21.6, 'clearsky_day'),
+      entry('2026-07-06T16:00:00Z', 18.2, 'cloudy'),
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.tempMax).toBe(22);
+    expect(day.tempMin).toBe(12);
+  });
+
+  it('picks the symbol of the timestep nearest 12:00 local, preferring next_6_hours', () => {
+    // Local noon in summer = 10:00Z. Middle entry wins.
+    const ts = [
+      entry('2026-07-06T06:00:00Z', 12, 'clearsky_day'),   // 08 local
+      entry('2026-07-06T10:00:00Z', 20, 'rain', 'fog'),    // 12 local -> next_6 'rain'
+      entry('2026-07-06T16:00:00Z', 18, 'cloudy'),         // 18 local
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.symbolCode).toBe('rain');
+  });
+
+  it('falls back to next_1_hours when next_6_hours is absent on the midday step', () => {
+    const ts = [
+      entry('2026-07-06T10:00:00Z', 20, undefined, 'lightrain'), // 12 local, only next_1
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.symbolCode).toBe('lightrain');
+  });
+
+  it('returns at most `days` days', () => {
+    const ts = Array.from({ length: 10 }, (_, i) =>
+      entry(`2026-07-${String(6 + i).padStart(2, '0')}T10:00:00Z`, 20, 'clearsky_day'),
+    );
+    expect(aggregateDailyForecast(ts, { days: 7 })).toHaveLength(7);
+  });
+
+  it('returns null temps when a day has no air_temperature', () => {
+    const ts: MetTimeseriesEntry[] = [
+      { time: '2026-07-06T10:00:00Z', data: { instant: { details: {} }, next_6_hours: { summary: { symbol_code: 'cloudy' } } } },
+    ];
+    const [day] = aggregateDailyForecast(ts);
+    expect(day.tempMax).toBeNull();
+    expect(day.tempMin).toBeNull();
+    expect(day.symbolCode).toBe('cloudy');
+  });
+});

--- a/fetcher-core/webui/app/lib/weather.ts
+++ b/fetcher-core/webui/app/lib/weather.ts
@@ -1,0 +1,93 @@
+export interface MetTimeseriesEntry {
+  time: string;
+  data: {
+    instant: { details: { air_temperature?: number } };
+    next_1_hours?: { summary: { symbol_code: string } };
+    next_6_hours?: { summary: { symbol_code: string } };
+    next_12_hours?: { summary: { symbol_code: string } };
+  };
+}
+
+export interface DailyForecast {
+  date: string; // YYYY-MM-DD in the configured timezone
+  symbolCode: string; // '' when no symbol is available for the day
+  tempMax: number | null;
+  tempMin: number | null;
+}
+
+const DEFAULT_TZ = 'Europe/Stockholm';
+
+// 'YYYY-MM-DD' for the given ISO instant in `tz`. en-CA gives ISO-ordered parts.
+function localDay(iso: string, tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(iso));
+}
+
+// Local hour-of-day (0-23) for the given ISO instant in `tz`.
+function localHour(iso: string, tz: string): number {
+  const h = new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    hour: '2-digit',
+    hour12: false,
+  }).format(new Date(iso));
+  // en-GB can yield '24' for midnight in some engines; normalise to 0.
+  return parseInt(h, 10) % 24;
+}
+
+function symbolOf(e: MetTimeseriesEntry): string | undefined {
+  return (
+    e.data.next_6_hours?.summary.symbol_code ??
+    e.data.next_1_hours?.summary.symbol_code ??
+    e.data.next_12_hours?.summary.symbol_code
+  );
+}
+
+export function aggregateDailyForecast(
+  timeseries: MetTimeseriesEntry[],
+  opts: { timeZone?: string; days?: number } = {},
+): DailyForecast[] {
+  const tz = opts.timeZone ?? DEFAULT_TZ;
+  const maxDays = opts.days ?? 7;
+
+  // Group entries by local day, preserving first-seen day order.
+  const byDay = new Map<string, MetTimeseriesEntry[]>();
+  for (const e of timeseries) {
+    const day = localDay(e.time, tz);
+    const bucket = byDay.get(day);
+    if (bucket) bucket.push(e);
+    else byDay.set(day, [e]);
+  }
+
+  const days: DailyForecast[] = [];
+  for (const [date, entries] of byDay) {
+    if (days.length >= maxDays) break;
+
+    const temps = entries
+      .map(e => e.data.instant.details.air_temperature)
+      .filter((t): t is number => typeof t === 'number');
+    const tempMax = temps.length ? Math.round(Math.max(...temps)) : null;
+    const tempMin = temps.length ? Math.round(Math.min(...temps)) : null;
+
+    // Symbol from the entry nearest 12:00 local that actually has a symbol.
+    const ranked = [...entries].sort(
+      (a, b) =>
+        Math.abs(localHour(a.time, tz) - 12) - Math.abs(localHour(b.time, tz) - 12),
+    );
+    let symbolCode = '';
+    for (const e of ranked) {
+      const s = symbolOf(e);
+      if (s) {
+        symbolCode = s;
+        break;
+      }
+    }
+
+    days.push({ date, symbolCode, tempMax, tempMin });
+  }
+
+  return days;
+}

--- a/fetcher-core/webui/app/page.tsx
+++ b/fetcher-core/webui/app/page.tsx
@@ -9,6 +9,7 @@ import PomodoroButton from './components/PomodoroButton';
 import SpeakersButton from './components/SpeakersButton';
 import useAutoReload from './hooks/useAutoReload';
 import EnergyPriceBar from './components/EnergyPriceBar';
+import WeatherBar from './components/WeatherBar';
 import SonosWidget from './components/SonosWidget';
 import { values } from './lib/values';
 import { Config, ConfigRow } from './lib/types';
@@ -50,6 +51,7 @@ export default function DashboardPage() {
       </div>
       <div className="w-full py-0 flex flex-col gap-1.5">
         <Grid values={values} onOpen={openFullscreen} />
+        <WeatherBar />
         <EnergyPriceBar />
         <SonosWidget />
       </div>

--- a/fetcher-core/webui/package-lock.json
+++ b/fetcher-core/webui/package-lock.json
@@ -25,7 +25,8 @@
         "@types/react": "^18.3.21",
         "@types/react-dom": "^18.3.7",
         "tailwindcss": "^4.1.6",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -49,6 +50,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@img/colour": {
@@ -727,6 +1119,356 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1254,6 +1996,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
@@ -1305,6 +2054,129 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1320,6 +2192,16 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1355,6 +2237,33 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1388,6 +2297,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/delayed-stream": {
@@ -1485,6 +2422,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1510,6 +2454,65 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1552,6 +2555,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1707,6 +2725,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1746,6 +2771,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1845,6 +2877,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1909,6 +2958,51 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/scheduler": {
@@ -1978,6 +3072,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/size-sensor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
@@ -1992,6 +3093,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -2037,6 +3152,50 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2063,6 +3222,172 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zrender": {
       "version": "6.0.0",

--- a/fetcher-core/webui/package.json
+++ b/fetcher-core/webui/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev 2>&1 | tee dev.log",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@influxdata/influxdb-client": "^1.35.0",
@@ -26,6 +27,7 @@
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "tailwindcss": "^4.1.6",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^2.1.9"
   }
 }


### PR DESCRIPTION
Adds a row of 7 daily weather boxes just above the energy price bar on the iPad dashboard.

## What
- **`/api/weather` route** — fetches YR / MET Norway *Locationforecast* server-side (required `User-Agent`), cached ~30 min, and aggregates the timeseries into 7 daily summaries `{ date, symbolCode, tempMax, tempMin }`.
- **`WeatherBar` component** — 7 equal boxes styled like `EnergyPriceBar`: Swedish weekday (first = "Idag"), MET weather icon (official MIT set via jsDelivr CDN), and `max° / min°`.
- **Aggregation helper** (`app/lib/weather.ts`) — groups timesteps by Europe/Stockholm calendar day, daily hi/lo from `air_temperature`, icon from the timestep nearest 12:00 local (prefers `next_6_hours`). Unit-tested with vitest (6 tests).

## Config
Location is env-configurable (server-side): `WEATHER_LAT` / `WEATHER_LON` / `WEATHER_ALTITUDE`, defaulting to **Kulladal, Malmö** (55.571 / 12.997 / 19).

## Verification
- `npm test` — 6/6 pass · `npm run typecheck` clean · `npm run build` succeeds (`/api/weather` route registered).
- Verified in-browser at desktop and iPad (768px) widths: `/api/weather` returns 7 days, icons load from the CDN, weekdays/temps render correctly in dark mode.

Spec: `docs/superpowers/specs/2026-07-06-weather-row-design.md` · Plan: `docs/superpowers/plans/2026-07-06-weather-row.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)