### PR TITLE
fix(sigenergy-bridge): retry metric writes on transient EOF

### DIFF
--- a/sigenergy-bridge/internal/metrics/influx.go
+++ b/sigenergy-bridge/internal/metrics/influx.go
@@ -7,6 +7,7 @@ package metrics
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -140,6 +141,27 @@ func NewHTTP(host, token, database string) *HTTPWriter {
 	}
 }
 
+// maxWriteAttempts bounds the retry loop in Write. Writes carry explicit
+// second-precision timestamps, so re-sending the same batch is idempotent
+// (VictoriaMetrics overwrites the same series+timestamp) — retrying is safe.
+const maxWriteAttempts = 3
+
+// writeRetryBackoff is the pause between attempts. Package-level so tests can
+// shorten it; the keep-alive EOF race resolves on the next connection, so a
+// short fixed backoff is enough.
+var writeRetryBackoff = 500 * time.Millisecond
+
+// statusError carries a non-2xx HTTP response so the retry logic can tell a
+// server-side 5xx (retryable) from a client-side 4xx (permanent).
+type statusError struct {
+	code int
+	body string
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("influx write %d: %s", e.code, e.body)
+}
+
 func (w *HTTPWriter) Write(ctx context.Context, points []*Point) error {
 	if len(points) == 0 {
 		return nil
@@ -160,8 +182,34 @@ func (w *HTTPWriter) Write(ctx context.Context, points []*Point) error {
 		body.WriteString(p.LineProtocol())
 		body.WriteString("\n")
 	}
+	bodyBytes := body.Bytes()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	var lastErr error
+	for attempt := 1; attempt <= maxWriteAttempts; attempt++ {
+		if attempt > 1 {
+			// Back off before retrying, but honour cancellation.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(writeRetryBackoff):
+			}
+		}
+		lastErr = w.writeOnce(ctx, endpoint, bodyBytes)
+		if lastErr == nil {
+			return nil
+		}
+		// 4xx (bad token, malformed line protocol) is permanent — retrying
+		// won't help, so fail fast. Retry only the transient cases: transport
+		// errors (the keep-alive EOF race, resets, timeouts) and 5xx.
+		if !isRetryableWriteErr(lastErr) {
+			return lastErr
+		}
+	}
+	return fmt.Errorf("influx write failed after %d attempts: %w", maxWriteAttempts, lastErr)
+}
+
+func (w *HTTPWriter) writeOnce(ctx context.Context, endpoint string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -175,7 +223,21 @@ func (w *HTTPWriter) Write(ctx context.Context, points []*Point) error {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("influx write %d: %s", resp.StatusCode, string(respBody))
+		return &statusError{code: resp.StatusCode, body: string(respBody)}
 	}
 	return nil
+}
+
+// isRetryableWriteErr reports whether a failed write is worth retrying. A
+// non-2xx status is retryable only when server-side (5xx); everything that
+// isn't a statusError is a transport/network error (EOF, connection reset,
+// timeout) — exactly the transient keep-alive races we want to retry. A
+// cancelled context surfaces here too, but the backoff select catches
+// ctx.Done() before another attempt runs.
+func isRetryableWriteErr(err error) bool {
+	var se *statusError
+	if errors.As(err, &se) {
+		return se.code >= 500
+	}
+	return true
 }

--- a/sigenergy-bridge/internal/metrics/influx.go
+++ b/sigenergy-bridge/internal/metrics/influx.go
@@ -151,6 +151,14 @@ const maxWriteAttempts = 3
 // short fixed backoff is enough.
 var writeRetryBackoff = 500 * time.Millisecond
 
+// maxWriteDuration caps the total wall-clock a single Write (all attempts and
+// backoffs) may consume. Write runs synchronously on the controller's single
+// select loop, so an unbounded retry against a hung VM would freeze clamp/
+// unclamp handling. Kept well below the default 60s poll interval so a metrics
+// outage can never outlast one poll cycle. Package-level so tests can shorten
+// it.
+var maxWriteDuration = 15 * time.Second
+
 // statusError carries a non-2xx HTTP response so the retry logic can tell a
 // server-side 5xx (retryable) from a client-side 4xx (permanent).
 type statusError struct {
@@ -183,6 +191,12 @@ func (w *HTTPWriter) Write(ctx context.Context, points []*Point) error {
 		body.WriteString("\n")
 	}
 	bodyBytes := body.Bytes()
+
+	// Bound the whole retry sequence so a hung endpoint can't block the
+	// caller's control loop longer than a poll cycle. The per-attempt
+	// http.Client timeout still applies within this budget.
+	ctx, cancel := context.WithTimeout(ctx, maxWriteDuration)
+	defer cancel()
 
 	var lastErr error
 	for attempt := 1; attempt <= maxWriteAttempts; attempt++ {

--- a/sigenergy-bridge/internal/metrics/influx_test.go
+++ b/sigenergy-bridge/internal/metrics/influx_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -144,4 +145,90 @@ func TestHTTPWriter_EmptyPoints(t *testing.T) {
 	if err := w.Write(context.Background(), nil); err != nil {
 		t.Errorf("empty batch should be a no-op, got %v", err)
 	}
+}
+
+// TestHTTPWriter_RetriesTransientEOF reproduces the keep-alive race: the first
+// attempt hijacks and abruptly closes the connection (client sees EOF), the
+// second succeeds. Write must recover instead of dropping the batch.
+func TestHTTPWriter_RetriesTransientEOF(t *testing.T) {
+	defer swapBackoff(1 * time.Millisecond)()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			conn.Close() // abrupt close → client's Do() returns EOF
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	w := NewHTTP(srv.URL, "tok", "b")
+	err := w.Write(context.Background(), []*Point{NewPoint("m").Field("v", 1).At(time.Unix(100, 0))})
+	if err != nil {
+		t.Fatalf("Write should recover after a transient EOF, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 attempts (1 fail + 1 retry), got %d", got)
+	}
+}
+
+// TestHTTPWriter_NoRetryOn4xx ensures a client-side error fails fast without
+// burning retries — a bad token or malformed batch won't fix itself.
+func TestHTTPWriter_NoRetryOn4xx(t *testing.T) {
+	defer swapBackoff(1 * time.Millisecond)()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	w := NewHTTP(srv.URL, "tok", "b")
+	err := w.Write(context.Background(), []*Point{NewPoint("m").Field("v", 1)})
+	if err == nil || !strings.Contains(err.Error(), "400") {
+		t.Fatalf("expected 400 error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("4xx must not be retried, made %d attempts", got)
+	}
+}
+
+// TestHTTPWriter_RetriesExhausted confirms a persistently failing endpoint
+// gives up after maxWriteAttempts and surfaces the underlying error.
+func TestHTTPWriter_RetriesExhausted(t *testing.T) {
+	defer swapBackoff(1 * time.Millisecond)()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	w := NewHTTP(srv.URL, "tok", "b")
+	err := w.Write(context.Background(), []*Point{NewPoint("m").Field("v", 1)})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&calls); got != maxWriteAttempts {
+		t.Errorf("expected %d attempts, got %d", maxWriteAttempts, got)
+	}
+}
+
+// swapBackoff shortens the retry backoff for a test and returns a restore func.
+func swapBackoff(d time.Duration) func() {
+	prev := writeRetryBackoff
+	writeRetryBackoff = d
+	return func() { writeRetryBackoff = prev }
 }

--- a/sigenergy-bridge/internal/metrics/influx_test.go
+++ b/sigenergy-bridge/internal/metrics/influx_test.go
@@ -226,9 +226,44 @@ func TestHTTPWriter_RetriesExhausted(t *testing.T) {
 	}
 }
 
+// TestHTTPWriter_BoundsTotalDuration ensures a hung endpoint is abandoned at
+// maxWriteDuration rather than blocking the caller's control loop indefinitely.
+func TestHTTPWriter_BoundsTotalDuration(t *testing.T) {
+	defer swapBackoff(1 * time.Millisecond)()
+	defer swapMaxDuration(50 * time.Millisecond)()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hang until the test tears down
+	}))
+	// LIFO: release the handler before Close(), so Close() doesn't block on it.
+	defer srv.Close()
+	defer close(release)
+
+	w := NewHTTP(srv.URL, "tok", "b")
+	start := time.Now()
+	err := w.Write(context.Background(), []*Point{NewPoint("m").Field("v", 1)})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a deadline error against a hung endpoint")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Write did not honour maxWriteDuration; took %v", elapsed)
+	}
+}
+
 // swapBackoff shortens the retry backoff for a test and returns a restore func.
 func swapBackoff(d time.Duration) func() {
 	prev := writeRetryBackoff
 	writeRetryBackoff = d
 	return func() { writeRetryBackoff = prev }
+}
+
+// swapMaxDuration shortens the total write budget for a test and returns a
+// restore func.
+func swapMaxDuration(d time.Duration) func() {
+	prev := maxWriteDuration
+	maxWriteDuration = d
+	return func() { maxWriteDuration = prev }
 }


### PR DESCRIPTION
## Problem
Sigenergy VM metric writes to vmauth intermittently failed with:
```
metrics write (poll) failed  err="Post \"http://localhost:8427/api/v2/write?bucket=irisgatan&precision=s\": EOF"
```
A few times/day the **entire batch was silently dropped** (WARN-only, no retry), leaving gaps in the sigenergy series.

**Root cause:** the classic Go keep-alive race — vmauth closes an idle keep-alive TCP connection, and the client's `http.Transport` reuses that half-closed socket on the next 60s poll before noticing, so `Client.Do` returns `EOF`.

## Fix
- Bounded retry in `HTTPWriter.Write` (3 attempts, 500ms backoff) on **transient transport errors** and **5xx**.
- **Fail fast on 4xx** (bad token / malformed line protocol won't fix itself).
- Safe because writes carry explicit second-precision timestamps → idempotent (VM overwrites same series+timestamp on re-send).

## Tests
- `TestHTTPWriter_RetriesTransientEOF` — reproduces the exact race by hijacking + abruptly closing the connection on attempt 1, succeeding on retry.
- `TestHTTPWriter_NoRetryOn4xx` — 400 fails fast, single attempt.
- `TestHTTPWriter_RetriesExhausted` — persistent 503 gives up after `maxWriteAttempts`.
- `go vet ./...` clean, full package suite green.

## Scope / not included
The nightly `192.168.68.77:502 network is unreachable` Modbus errors are device/network-side (inverter has a DHCP reservation; drops ~22:20 nightly, self-recovers). Not addressed here — a skipped poll self-heals on the next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)