### PR TITLE
fix(sigenergy-bridge): fix data race in ha websocket test

### DIFF
--- a/sigenergy-bridge/internal/ha/ws_test.go
+++ b/sigenergy-bridge/internal/ha/ws_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -113,9 +114,11 @@ func TestDial_AuthOK_ForwardsMatchingEvent(t *testing.T) {
 }
 
 func TestDial_AuthInvalid_Stops(t *testing.T) {
-	connectCount := 0
+	// connectCount is written by the server-handler goroutine and read by the
+	// test goroutine, so it must be accessed atomically to stay race-free.
+	var connectCount atomic.Int32
 	url, stop := newTestServer(t, func(c *websocket.Conn, t *testing.T) {
-		connectCount++
+		connectCount.Add(1)
 		_ = c.WriteJSON(map[string]any{"type": "auth_required"})
 		var auth map[string]any
 		if err := c.ReadJSON(&auth); err != nil {
@@ -135,8 +138,8 @@ func TestDial_AuthInvalid_Stops(t *testing.T) {
 
 	// Connected may or may not have emitted; we only assert that the loop
 	// stopped reconnecting. Count should be exactly 1.
-	if connectCount != 1 {
-		t.Errorf("expected 1 connect on auth_invalid, got %d", connectCount)
+	if got := connectCount.Load(); got != 1 {
+		t.Errorf("expected 1 connect on auth_invalid, got %d", got)
 	}
 	_ = l
 }


### PR DESCRIPTION
## Problem
`TestDial_AuthInvalid_Stops` fails under `go test -race` (passes without it). A plain `int connectCount` is written by the httptest server-handler goroutine and read by the test goroutine with no synchronization:

```
Read at ws_test.go:138 by goroutine 8 (test)
Previous write at ws_test.go:118 by goroutine 11 (server handler)
```

Pre-existing; surfaced while running `-race` during #397.

## Fix
Make `connectCount` an `atomic.Int32` (`.Add(1)` in the handler, `.Load()` in the assertion). Test-only change — production `ws.go` is unaffected.

## Verification
- `go test ./internal/ha/ -race -count=5` — clean
- `go test ./... -race` (whole module) — green
- `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)