### PR TITLE
fix(sonos): inject GEMINI_API_KEY into sonos-http-api for TTS say

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -57,6 +57,7 @@ services:
 
   sonos-http-api:
     container_name: sonos-http-api
+    env_file: ./sonos-http-api/.env
     volumes:
       - ./sonos-http-api/settings.json:/app/settings.json:ro
 


### PR DESCRIPTION
## Problem
The web UI "say" feature produced no audio. Root cause was two layers:

1. **Wiring:** `sonos-http-api` synthesizes speech via **Gemini TTS**, and `sonos-http-api/settings.json` references `"geminiKey": "${GEMINI_API_KEY}"` — but neither compose file injected `GEMINI_API_KEY` into the container, so the placeholder resolved empty.
2. **Dead key:** the only Gemini key in the stack had been deleted → `400 API_KEY_INVALID`.

Logs showed:
```
WARN Environment variable GEMINI_API_KEY is not set and has no default
ERROR Gemini TTS failed with status 400: "API key not valid" / API_KEY_INVALID
```

## Fix
- Add `env_file: ./sonos-http-api/.env` to the `sonos-http-api` service so the container receives `GEMINI_API_KEY` (the `.env` is gitignored, created on rpi5).
- A fresh Gemini key was issued in a new GCP project (`iot-fetcher`) and placed in `sonos-http-api/.env` on rpi5.

## Test plan
**Local / pre-merge (done on rpi5):**
- `curl http://localhost:5005/Kontor/say/...` → `{"status":"success"}`
- Logs show `downloading from Gemini TTS` with no subsequent error
- Key verified: `models?key=...` → HTTP 200

**Post-merge:**
- rpi5 pulls `main`; reset the manual working-tree edit first, then `git pull`
- Confirm say still works from the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)