### PR TITLE
feat(webui): serve car SoC from the Garmin metrics endpoint

### DIFF
--- a/.claude/skills/victoria-metrics/SKILL.md
+++ b/.claude/skills/victoria-metrics/SKILL.md
@@ -33,8 +33,12 @@ VictoriaMetrics runs on rpi5 (container name `database`, `-httpListenAddr=:8181`
 
 ## Credentials
 
-- `scripts/vm-query.sh` and `scripts/vm-rename.sh` read `INFLUX_TOKEN` from `fetcher-core/python/.env` and `PROXY_DOMAIN` from `https-proxy/.env` — no shell prep needed.
-- `scripts/vm-shape.sh` reads `INFLUX_HOST` + `INFLUX_TOKEN` from `fetcher-core/python/.env.local`.
+- All three scripts resolve credentials through `scripts/vm-env.sh` — no shell prep needed.
+- Resolution order per value: an already-exported env var first, then the first `.env` file that defines the key.
+  - Endpoint: `VM_BASE_URL`, else `PROXY_DOMAIN` (→ `https://$PROXY_DOMAIN`), else `INFLUX_HOST`.
+  - Token: `INFLUX_TOKEN`.
+  - Files checked, in order: `fetcher-core/python/.env.local`, `fetcher-core/python/.env`, `https-proxy/.env.local`, `https-proxy/.env`.
+- A fresh clone or container has no `.env` files. The scripts then fail with an explicit "could not resolve VictoriaMetrics credentials" message listing what to set — that is a missing-credentials problem, not a broken script. Export the two vars to query from such an environment.
 - All scripts are worktree-safe (they resolve the main repo root via `git rev-parse --git-common-dir`).
 
 ## Anti-patterns

--- a/fetcher-core/webui/README.md
+++ b/fetcher-core/webui/README.md
@@ -29,7 +29,28 @@ webui/
 - `GET /influx/api/v2/health` - Proxy to InfluxDB health check
 
 ### Metrics
-- `GET /metrics/garmin` - Get Garmin device metrics
+- `GET /metrics/garmin` - Semi-structured tile list for the Garmin watch app
+
+  Returns a JSON array of tiles, each carrying its own rendering hints so the
+  watch app needs no per-metric knowledge:
+
+  ```json
+  [
+    { "title": "Batteri",   "unit": "%",  "decimals": 0, "key": "battery_soc", "data": 64 },
+    { "title": "Solceller", "unit": "kW", "decimals": 1, "key": "solar_power", "data": 2.5 },
+    { "title": "Inkop",     "unit": "kW", "decimals": 1, "key": "grid_power",  "data": -1.25 },
+    { "title": "Bil",       "unit": "%",  "decimals": 0, "key": "car_soc",     "data": 82 }
+  ]
+  ```
+
+  - Tile order is stable (it follows `METRIC_DEFS`), so the watch layout does
+    not shuffle between polls.
+  - A metric with no data is omitted rather than sent as null; the response is
+    `500 {"error": "No data available"}` only when every metric is missing.
+  - `car_soc` comes from `ha_volvo_xc40_battery_value`. The car only reports
+    while awake, so it is read as `last_over_time(...[24h])` instead of the 5m
+    average used for the frequently-sampled sigenergy metrics.
+  - Titles are ASCII on purpose — the watch font lacks Swedish diacritics.
 
 ### Sonos
 - `GET /sonos/*` - Proxy to Sonos API

--- a/fetcher-core/webui/app/api/metrics/[device]/route.test.ts
+++ b/fetcher-core/webui/app/api/metrics/[device]/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+// Captures the PromQL of every query the route issues, keyed by nothing —
+// order matches the route's fan-out, which is not guaranteed, so assert by match.
+let queries: string[] = [];
+
+/** Stub VM: returns `values[metricName]`, or an empty result if absent. */
+function stubVictoriaMetrics(values: Record<string, number>) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    const query = new URL(url).searchParams.get('query') ?? '';
+    queries.push(query);
+    const name = Object.keys(values).find((m) => query.includes(m));
+    const result = name === undefined ? [] : [{
+      metric: { __name__: name },
+      value: [1753447000, String(values[name])],
+    }];
+    return {
+      ok: true,
+      json: async () => ({ status: 'success', data: { resultType: 'vector', result } }),
+    };
+  }));
+}
+
+function call(device = 'garmin') {
+  return GET(
+    new NextRequest(`http://localhost/api/metrics/${device}`),
+    { params: Promise.resolve({ device }) },
+  );
+}
+
+const ALL_METRICS = {
+  sigenergy_battery_soc_percent: 64,
+  sigenergy_pv_power_power_kw: 2.5,
+  sigenergy_grid_power_net_power_kw: -1.25,
+  ha_volvo_xc40_battery_value: 82,
+};
+
+describe('GET /api/metrics/garmin', () => {
+  beforeEach(() => {
+    queries = [];
+    process.env.INFLUX_HOST = 'http://vm.test';
+    process.env.INFLUX_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('includes the car SoC tile', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    const body = await (await call()).json();
+
+    expect(body).toContainEqual({
+      title: 'Bil',
+      unit: '%',
+      decimals: 0,
+      key: 'car_soc',
+      data: 82,
+    });
+  });
+
+  it('reads car SoC as the last sample over a long window, since the car reports sparsely', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    await call();
+
+    const carQuery = queries.find((q) => q.includes('ha_volvo_xc40_battery_value'));
+    expect(carQuery).toBe('last_over_time(ha_volvo_xc40_battery_value[24h])');
+  });
+
+  it('keeps the existing 5m average for the frequently-sampled sigenergy metrics', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    await call();
+
+    expect(queries).toContain('avg_over_time(sigenergy_battery_soc_percent[5m])');
+    expect(queries).toContain('avg_over_time(sigenergy_pv_power_power_kw{string="total"}[5m])');
+    expect(queries).toContain('avg_over_time(sigenergy_grid_power_net_power_kw[5m])');
+  });
+
+  it('does not leak query internals into the payload', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    const body = await (await call()).json();
+
+    for (const tile of body) {
+      expect(Object.keys(tile).sort()).toEqual(
+        ['data', 'decimals', 'key', 'title', 'unit'],
+      );
+    }
+  });
+
+  it('returns tiles in a stable order so the watch layout does not shuffle', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    const body = await (await call()).json();
+
+    expect(body.map((t: { key: string }) => t.key)).toEqual(
+      ['battery_soc', 'solar_power', 'grid_power', 'car_soc'],
+    );
+  });
+
+  it('omits a tile when the car has not reported, keeping the others in order', async () => {
+    const { ha_volvo_xc40_battery_value: _absent, ...rest } = ALL_METRICS;
+    stubVictoriaMetrics(rest);
+    const body = await (await call()).json();
+
+    expect(body.map((t: { key: string }) => t.key)).toEqual(
+      ['battery_soc', 'solar_power', 'grid_power'],
+    );
+  });
+
+  it('rejects unsupported devices', async () => {
+    stubVictoriaMetrics(ALL_METRICS);
+    expect((await call('fitbit')).status).toBe(400);
+  });
+});

--- a/fetcher-core/webui/app/api/metrics/[device]/route.ts
+++ b/fetcher-core/webui/app/api/metrics/[device]/route.ts
@@ -1,13 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const METRIC_DEFS = [
+type MetricDef = {
+  title: string;
+  unit: string;
+  decimals: number;
+  key: string;
+  metric: string;
+  labels: Record<string, string>;
+  /** Range-vector aggregation applied to the selector. Defaults to avg_over_time. */
+  agg?: string;
+  /** Range-vector window. Defaults to 5m. */
+  window?: string;
+};
+
+// Titles are rendered by the Garmin watch app, whose font has no Swedish
+// diacritics — keep them ASCII ("Inkop", not "Inköp").
+const METRIC_DEFS: MetricDef[] = [
   {
     title: "Batteri",
     unit: "%",
     decimals: 0,
     key: "battery_soc",
     metric: "sigenergy_battery_soc_percent",
-    labels: {} as Record<string, string>,
+    labels: {},
   },
   {
     title: "Solceller",
@@ -23,7 +38,20 @@ const METRIC_DEFS = [
     decimals: 1,
     key: "grid_power",
     metric: "sigenergy_grid_power_net_power_kw",
-    labels: {} as Record<string, string>,
+    labels: {},
+  },
+  {
+    title: "Bil",
+    unit: "%",
+    decimals: 0,
+    key: "car_soc",
+    metric: "ha_volvo_xc40_battery_value",
+    labels: {},
+    // The car only reports while awake/connected, so samples are sparse and
+    // averaging a 5m window usually yields nothing. Take the last known SoC
+    // over a long window instead.
+    agg: "last_over_time",
+    window: "24h",
   },
 ];
 
@@ -47,9 +75,7 @@ export async function GET(
     return new NextResponse('Missing INFLUX_TOKEN', { status: 500 });
   }
 
-  const results: any[] = [];
-
-  for (const d of METRIC_DEFS) {
+  const settled = await Promise.all(METRIC_DEFS.map(async (d) => {
     const labelSelector = Object.entries(d.labels)
       .map(([k, v]) => `${k}="${v}"`)
       .join(',');
@@ -57,7 +83,7 @@ export async function GET(
     if (labelSelector) {
       selector += '{' + labelSelector + '}';
     }
-    const query = `avg_over_time(${selector}[5m])`;
+    const query = `${d.agg ?? 'avg_over_time'}(${selector}[${d.window ?? '5m'}])`;
 
     try {
       const resp = await fetch(
@@ -74,7 +100,7 @@ export async function GET(
 
       if (!resp.ok) {
         console.warn(`PromQL query failed for ${d.key}: ${await resp.text()}`);
-        continue;
+        return null;
       }
 
       const data = await resp.json();
@@ -82,16 +108,20 @@ export async function GET(
 
       if (promResult.length > 0) {
         const value = parseFloat(promResult[0].value[1]);
-        const { metric: _m, labels: _l, ...meta } = d;
-        results.push({ ...meta, data: value });
-      } else {
-        console.warn(`No data returned for ${d.key}`);
+        const { metric: _m, labels: _l, agg: _a, window: _w, ...meta } = d;
+        return { ...meta, data: value };
       }
+
+      console.warn(`No data returned for ${d.key}`);
+      return null;
     } catch (e) {
       console.error(`Error querying for ${d.key}:`, e);
-      continue;
+      return null;
     }
-  }
+  }));
+
+  // Preserves METRIC_DEFS order, so the watch app's tile layout stays stable.
+  const results = settled.filter((r) => r !== null);
 
   if (results.length === 0) {
     return NextResponse.json({ error: "No data available" }, { status: 500 });

--- a/scripts/vm-env.sh
+++ b/scripts/vm-env.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Sourced by the vm-*.sh helpers to resolve VictoriaMetrics credentials.
+#
+# Exports:
+#   VM_BASE_URL  base URL of the VM API (no trailing slash)
+#   VM_TOKEN     bearer token
+#
+# Each value is resolved from, in order:
+#   1. An already-set environment variable — so the scripts also work in
+#      containers, CI, and fresh clones that have no .env files at all.
+#   2. The first candidate .env file that defines the key.
+#
+# .env files are not committed, so in a git worktree they only exist in the main
+# worktree root. git-common-dir is shared across all worktrees; its parent is
+# the canonical checkout.
+
+_vm_env_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if _vm_common_dir="$(git -C "$_vm_env_script_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+  VM_ENV_DIR="$(cd "$_vm_common_dir/.." && pwd)"
+else
+  VM_ENV_DIR="$(cd "$_vm_env_script_dir/.." && pwd)"
+fi
+
+_vm_python_envs=(
+  "$VM_ENV_DIR/fetcher-core/python/.env.local"
+  "$VM_ENV_DIR/fetcher-core/python/.env"
+)
+_vm_proxy_envs=(
+  "$VM_ENV_DIR/https-proxy/.env.local"
+  "$VM_ENV_DIR/https-proxy/.env"
+)
+
+# _vm_read_env <key> <file>...  — echo the first non-empty value found, else nothing.
+_vm_read_env() {
+  local key="$1"; shift
+  local file value
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    value="$(grep -m1 "^${key}=" "$file" | cut -d'=' -f2-)"
+    # Strip surrounding quotes, which are legal in .env files.
+    value="${value%\"}"; value="${value#\"}"
+    value="${value%\'}"; value="${value#\'}"
+    if [[ -n "$value" ]]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  done
+  return 0
+}
+
+VM_TOKEN="${INFLUX_TOKEN:-$(_vm_read_env INFLUX_TOKEN "${_vm_python_envs[@]}")}"
+
+if [[ -z "${VM_BASE_URL:-}" ]]; then
+  _vm_domain="${PROXY_DOMAIN:-$(_vm_read_env PROXY_DOMAIN "${_vm_proxy_envs[@]}")}"
+  if [[ -n "$_vm_domain" ]]; then
+    VM_BASE_URL="https://${_vm_domain}"
+  else
+    _vm_host="${INFLUX_HOST:-$(_vm_read_env INFLUX_HOST "${_vm_python_envs[@]}")}"
+    VM_BASE_URL="${_vm_host%/}"
+  fi
+else
+  VM_BASE_URL="${VM_BASE_URL%/}"
+fi
+
+if [[ -z "$VM_BASE_URL" || -z "$VM_TOKEN" ]]; then
+  {
+    echo "Error: could not resolve VictoriaMetrics credentials."
+    echo
+    [[ -z "$VM_BASE_URL" ]] && echo "  missing endpoint — set VM_BASE_URL, PROXY_DOMAIN, or INFLUX_HOST"
+    [[ -z "$VM_TOKEN" ]] && echo "  missing token    — set INFLUX_TOKEN"
+    echo
+    echo "Either export them, or provide them in one of:"
+    printf '  %s\n' "${_vm_python_envs[@]}" "${_vm_proxy_envs[@]}"
+    echo
+    echo "Note: .env files are not committed, so a fresh clone has none of them."
+  } >&2
+  exit 1
+fi
+
+export VM_BASE_URL VM_TOKEN

--- a/scripts/vm-query.sh
+++ b/scripts/vm-query.sh
@@ -2,15 +2,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# .env files are not committed, so in a git worktree they only exist in the main worktree root.
-# git-common-dir is shared across all worktrees; its parent is the canonical checkout.
-ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
+# Resolves VM_BASE_URL / VM_TOKEN from the environment or the repo's .env files.
+source "$SCRIPT_DIR/vm-env.sh"
 
-TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
-DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)
-BASE_URL="https://${DOMAIN}"
+TOKEN="$VM_TOKEN"
+BASE_URL="$VM_BASE_URL"
 
 usage() {
   cat <<EOF

--- a/scripts/vm-rename.sh
+++ b/scripts/vm-rename.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-ENV_DIR="$(cd "$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
+# Resolves VM_BASE_URL / VM_TOKEN from the environment or the repo's .env files.
+source "$SCRIPT_DIR/vm-env.sh"
 
-TOKEN=$(grep '^INFLUX_TOKEN=' "$ENV_DIR/fetcher-core/python/.env" | cut -d'=' -f2-)
-DOMAIN=$(grep '^PROXY_DOMAIN=' "$ENV_DIR/https-proxy/.env" | cut -d'=' -f2-)
-BASE_URL="https://${DOMAIN}"
+TOKEN="$VM_TOKEN"
+BASE_URL="$VM_BASE_URL"
 
 usage() {
   cat <<EOF

--- a/scripts/vm-shape.sh
+++ b/scripts/vm-shape.sh
@@ -1,26 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Resolve the main repo root even when invoked from a worktree — the common
-# .git dir is shared across all worktrees of a repo, so its parent is the
-# canonical checkout that holds fetcher-core/python/.env.local.
-GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
-REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
-
-ENV_FILE="$REPO_ROOT/fetcher-core/python/.env.local"
-[[ -f "$ENV_FILE" ]] || { echo "Missing $ENV_FILE" >&2; exit 1; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 for bin in curl jq; do
   command -v "$bin" >/dev/null 2>&1 || { echo "Missing required binary: $bin" >&2; exit 1; }
 done
 
-INFLUX_HOST="$(grep -E '^INFLUX_HOST=' "$ENV_FILE" | cut -d'=' -f2-)"
-INFLUX_TOKEN="$(grep -E '^INFLUX_TOKEN=' "$ENV_FILE" | cut -d'=' -f2-)"
-[[ -n "$INFLUX_HOST" && -n "$INFLUX_TOKEN" ]] \
-  || { echo "INFLUX_HOST / INFLUX_TOKEN missing in $ENV_FILE" >&2; exit 1; }
+# Resolves VM_BASE_URL / VM_TOKEN from the environment or the repo's .env files.
+source "$SCRIPT_DIR/vm-env.sh"
 
-BASE_URL="${INFLUX_HOST%/}"
-AUTH_HEADER="Authorization: Bearer ${INFLUX_TOKEN}"
+BASE_URL="$VM_BASE_URL"
+AUTH_HEADER="Authorization: Bearer ${VM_TOKEN}"
 
 PATTERN="${1:-}"
 


### PR DESCRIPTION
## Car SoC on the watch

Adds a **`Bil`** tile to `GET /metrics/garmin`, sourced from `ha_volvo_xc40_battery_value` — the same XC40 battery metric the webui tile (`app/lib/values.ts`) and the Grafana battery panel (`grafana/src/panels/volvo.ts`) already use.

```json
[
  { "title": "Batteri",   "unit": "%",  "decimals": 0, "key": "battery_soc", "data": 64 },
  { "title": "Solceller", "unit": "kW", "decimals": 1, "key": "solar_power", "data": 2.5 },
  { "title": "Inkop",     "unit": "kW", "decimals": 1, "key": "grid_power",  "data": -1.25 },
  { "title": "Bil",       "unit": "%",  "decimals": 0, "key": "car_soc",     "data": 82 }
]
```

Purely additive to the payload — existing tiles keep their shape, keys, and order.

### Sparse sampling

The car only reports while awake/connected, so its samples are sparse and the endpoint's hardcoded `avg_over_time(...[5m])` would usually return nothing. Metric defs now carry an optional `agg`/`window`, defaulting to the previous `avg_over_time`/`5m`, and car SoC uses `last_over_time(ha_volvo_xc40_battery_value[24h])`. **The three sigenergy queries are byte-for-byte unchanged.**

### Also in this commit

- Queries fan out concurrently, so a fourth metric doesn't add another serial 10s timeout to a watch poll.
- `agg`/`window` are stripped from the response alongside `metric`/`labels`.
- Tile order still follows `METRIC_DEFS`, so the watch layout doesn't shuffle between polls.
- Route tests covering the payload contract the watch app depends on: tile presence, the two query shapes, key set, stable order, and the omit-on-missing-data path.

## Sidetask: VM credential resolution

`vm-query.sh` and `vm-rename.sh` grepped `fetcher-core/python/.env` and `https-proxy/.env` unconditionally, so on a checkout without them they died with a bare `grep: .../.env: No such file or directory` that says nothing about what's missing. `vm-shape.sh` had the same problem against a third path, `.env.local`, which the other two never consulted.

Factored into a shared `scripts/vm-env.sh`: each value comes from an already-exported env var if set, else the first candidate `.env`/`.env.local` that defines it (surrounding quotes stripped). Missing credentials now report which value is absent and where it can come from, and the scripts work in environments with no `.env` at all by exporting `INFLUX_TOKEN` plus `VM_BASE_URL`, `PROXY_DOMAIN`, or `INFLUX_HOST`.

⚠️ **Behavior change:** `vm-shape.sh` now prefers a `PROXY_DOMAIN`-derived URL over `INFLUX_HOST`, matching the other two scripts. `INFLUX_HOST` remains the fallback when no `PROXY_DOMAIN` is configured — worth a sanity check if you relied on `vm-shape.sh` pointing at a different endpoint than the proxy.

## Test plan

- `npm run typecheck` — clean
- `npm test` — 13 passed (7 new)
- Credential resolution exercised across all three paths: env-var override, `.env` fallback with quoted values, and the missing-credentials error

**Not verified against live data.** This session ran in a remote container with no `.env` files and no network route to VM, so I could not confirm the live shape of `ha_volvo_xc40_battery_value` — the metric name comes from the two existing in-repo consumers. Worth one local check that the `24h` window is generous enough for how often the XC40 actually reports:

```
./scripts/vm-query.sh query 'last_over_time(ha_volvo_xc40_battery_value[24h])'
```

Note there's also a `ha_xc40_state_of_charge` series used in the Grafana panel; I went with `ha_volvo_xc40_battery_value` for consistency with the existing battery tile, but say the word if the other one is the better source.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mV22mLDokaCnpphMoLfRZ)_