### PR TITLE
feat(grafana): alert on stale Volvo XC40 metrics (4h → Slack)

### DIFF
--- a/grafana/src/alerts/alerts.test.ts
+++ b/grafana/src/alerts/alerts.test.ts
@@ -22,7 +22,7 @@ test('alerts build into a single Irisgatan group', () => {
   const groups = buildAlerts() as RuleGroup[];
   assert.equal(groups.length, 1);
   assert.equal(groups[0].title, 'Irisgatan');
-  assert.equal(groups[0].rules?.length, 2);
+  assert.equal(groups[0].rules?.length, 4);
 });
 
 test('every rule has the four required identity fields', () => {

--- a/grafana/src/alerts/delta-t-varmevaxlaren.ts
+++ b/grafana/src/alerts/delta-t-varmevaxlaren.ts
@@ -1,0 +1,32 @@
+import * as alerting from '@grafana/grafana-foundation-sdk/alerting';
+import { reduceExpr, thresholdExpr, vmAlertQuery } from './helpers.ts';
+
+/**
+ * ΔT across the heat exchanger (outgoing − incoming). Fires when the
+ * difference stays above 3.25 °C for 6h — a sign of poor heat transfer.
+ *
+ * Backported verbatim from a UI-created rule (uid efrq0w4q0v4e8a) so the
+ * Irisgatan group stays fully code-owned; the provisioning PUT replaces the
+ * whole group, so a rule missing here would be deleted on the next deploy.
+ */
+export function deltaTVarmevaxlaren(): alerting.RuleBuilder {
+  return new alerting.RuleBuilder('ΔT över värmeväxlaren')
+    .uid('efrq0w4q0v4e8a')
+    .ruleGroup('Irisgatan')
+    .condition('C')
+    .forDuration('6h')
+    .keepFiringFor('2h')
+    .noDataState('NoData')
+    .execErrState('Error')
+    .annotations({ __dashboardUid__: 'irisgatan-v3', __panelId__: '19' })
+    .notificationSettings(new alerting.NotificationSettingsBuilder().receiver('Slack'))
+    .withQuery(
+      vmAlertQuery('A', 'avg_over_time(aqua_temp_temp_outgoing[5m]) - avg_over_time(aqua_temp_temp_incoming[5m])', {
+        legendFormat: 'delta_t',
+        intervalMs: 300000,
+        rangeSeconds: 21600,
+      }),
+    )
+    .withQuery(reduceExpr('B', 'A', 'last'))
+    .withQuery(thresholdExpr('C', 'B', 'gt', 3.25));
+}

--- a/grafana/src/alerts/index.ts
+++ b/grafana/src/alerts/index.ts
@@ -1,6 +1,8 @@
 import * as alerting from '@grafana/grafana-foundation-sdk/alerting';
 import { poolpumpInaktiv } from './poolpump-inaktiv.ts';
 import { energiPerFas } from './energi-per-fas.ts';
+import { deltaTVarmevaxlaren } from './delta-t-varmevaxlaren.ts';
+import { volvoMetricsStale } from './volvo-metrics-stale.ts';
 
 const FOLDER_UID_FALLBACK = 'beveqmuomx5hcd';
 
@@ -10,7 +12,7 @@ const FOLDER_UID_FALLBACK = 'beveqmuomx5hcd';
  * inside a group share an evaluation cadence — see GROUP_INTERVAL.
  */
 export function buildAlerts(folderUID = FOLDER_UID_FALLBACK): alerting.RuleGroup[] {
-  const rules = [poolpumpInaktiv(), energiPerFas()];
+  const rules = [poolpumpInaktiv(), energiPerFas(), deltaTVarmevaxlaren(), volvoMetricsStale()];
 
   // Stamp the resolved folder UID onto each rule. The Foundation SDK
   // requires it on Rule (it's part of the persisted shape), even though

--- a/grafana/src/alerts/volvo-metrics-stale.ts
+++ b/grafana/src/alerts/volvo-metrics-stale.ts
@@ -1,0 +1,40 @@
+import * as alerting from '@grafana/grafana-foundation-sdk/alerting';
+import { reduceExpr, thresholdExpr, vmAlertQuery } from './helpers.ts';
+
+/**
+ * Fires when the Volvo XC40 metrics go stale — no new sample for 4h — which
+ * means the Home Assistant Volvo integration has stopped reporting.
+ *
+ * `ha_volvo_xc40_battery_value` is the sentinel: all six Volvo series update
+ * in lockstep (same scrape), so battery going stale means the whole group is.
+ *
+ * Staleness detection: `count_over_time(sentinel[4h])` returns the sample
+ * count over the trailing 4h; VictoriaMetrics returns an *empty* result once
+ * that window holds zero samples. `or vector(0)` turns that emptiness into a
+ * concrete 0 so the threshold fires on a real value rather than depending on
+ * noDataState. The 4h window itself is the delay, so the pending period is 0.
+ */
+export function volvoMetricsStale(): alerting.RuleBuilder {
+  return new alerting.RuleBuilder('Volvo XC40 data saknas')
+    .uid('volvo-stale-4h')
+    .ruleGroup('Irisgatan')
+    .condition('C')
+    .forDuration('0s')
+    .noDataState('Alerting')
+    .execErrState('Error')
+    .annotations({
+      __dashboardUid__: 'irisgatan-v3',
+      __panelId__: '44',
+      summary: 'Inga nya Volvo XC40-mätvärden på 4h — HA-integrationen kan ha slutat rapportera',
+    })
+    .notificationSettings(new alerting.NotificationSettingsBuilder().receiver('Slack'))
+    .withQuery(
+      vmAlertQuery('A', 'count_over_time(ha_volvo_xc40_battery_value[4h]) or vector(0)', {
+        legendFormat: 'samples_4h',
+        intervalMs: 60000,
+        rangeSeconds: 600,
+      }),
+    )
+    .withQuery(reduceExpr('B', 'A', 'last'))
+    .withQuery(thresholdExpr('C', 'B', 'lt', 1));
+}


### PR DESCRIPTION
## What
Adds a Grafana alert that fires when the **Volvo XC40 metrics go stale** — no new sample for `ha_volvo_xc40_battery_value` in **4h** — and routes it to the existing **Slack** contact point. This catches the Home Assistant Volvo integration silently dying.

### How the staleness check works
```
count_over_time(ha_volvo_xc40_battery_value[4h]) or vector(0)   → reduce(last) → threshold(lt 1)
```
- The `[4h]` window is the delay, so the pending period is `0s` — fires exactly when data has been absent 4h.
- `or vector(0)` turns VM's empty result into a concrete `0`, so the threshold fires on a real value instead of relying on `noDataState`. Validated live: present → 48, stale window → 0, absent metric → 0.
- Sentinel is battery `%`; all six Volvo series update in lockstep, so one stale means the group is stale.

## Also: backports a drifted rule 🚨
While auditing live Grafana via the provisioning API I found **3 live rules but only 2 in code**. The extra one — **`ΔT över värmeväxlaren`** (`uid efrq0w4q0v4e8a`, UI-created) — was not in the repo.

The deploy (`uploadAlertGroups`) does a **`PUT` of the entire `Irisgatan` rule-group**, which *replaces* its rules. So merging any alert change without this rule present would have **deleted it from Grafana**. This PR backports it verbatim (for 6h, keep_firing_for 2h, noData=NoData, Slack) so the group is fully code-owned.

## Rules in the Irisgatan group after this PR
| Rule | for | receiver |
|---|---|---|
| Poolpump inaktiv | 3h | Grafana |
| Energi per fas | 5m | Slack |
| ΔT över värmeväxlaren *(backported)* | 6h | Slack |
| **Volvo XC40 data saknas** *(new)* | 4h window | Slack |

## Test
- `npm test` — 5/5 pass (rule count 2→4, unique UIDs, condition refIds valid).
- `npm run build` — alerts.json generates cleanly; verified expr/annotations/receiver per rule.
- Deploy is via the existing `grafana-dashboard.yml` workflow on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)