### PR TITLE
fix(grafana): stop Volvo stale-alert firing on fresh data

### DIFF
--- a/grafana/src/alerts/volvo-metrics-stale.ts
+++ b/grafana/src/alerts/volvo-metrics-stale.ts
@@ -13,6 +13,14 @@ import { reduceExpr, thresholdExpr, vmAlertQuery } from './helpers.ts';
  * that window holds zero samples. `or vector(0)` turns that emptiness into a
  * concrete 0 so the threshold fires on a real value rather than depending on
  * noDataState. The 4h window itself is the delay, so the pending period is 0.
+ *
+ * The `sum(...)` wrapper is load-bearing: without it, `count_over_time(...)`
+ * keeps the metric's labels while `vector(0)` has an empty label set, so `or`
+ * returns BOTH series when data is present (e.g. `48{...}` AND `0{}`). Grafana
+ * reduces each series independently, so the phantom `0{}` trips `lt 1` and the
+ * rule fires even when data is fresh. `sum` collapses the count to a single
+ * `{}` series that shares vector(0)'s label set, so `or` drops the fallback
+ * whenever real data exists.
  */
 export function volvoMetricsStale(): alerting.RuleBuilder {
   return new alerting.RuleBuilder('Volvo XC40 data saknas')
@@ -29,7 +37,7 @@ export function volvoMetricsStale(): alerting.RuleBuilder {
     })
     .notificationSettings(new alerting.NotificationSettingsBuilder().receiver('Slack'))
     .withQuery(
-      vmAlertQuery('A', 'count_over_time(ha_volvo_xc40_battery_value[4h]) or vector(0)', {
+      vmAlertQuery('A', 'sum(count_over_time(ha_volvo_xc40_battery_value[4h])) or vector(0)', {
         legendFormat: 'samples_4h',
         intervalMs: 60000,
         rangeSeconds: 600,


### PR DESCRIPTION
## Problem
The Volvo staleness alert merged in #414 **fires immediately on fresh data** — it paged even though metrics are current. The fix commit from that session never made it into #414's squash-merge, so `main` shipped the buggy query and CI deployed it.

## Root cause
The rule's query was:
```
count_over_time(ha_volvo_xc40_battery_value[4h]) or vector(0)
```
`vector(0)` has an empty label set `{}`; `count_over_time(...)` keeps the metric's labels. `or` matches on label sets, so when data is present it returns **both** series:
```
48  {device_class="battery",...}
0   {}          ← phantom, always 0
```
Grafana reduces each series independently, so the phantom `0{}` trips the `lt 1` threshold and the rule fires regardless of freshness. Confirmed live: the firing instance was `{}` with value `1`.

## Fix
```
sum(count_over_time(ha_volvo_xc40_battery_value[4h])) or vector(0)
```
`sum` collapses the count to a single `{}` series that shares `vector(0)`'s label set, so `or` drops the fallback whenever real data exists. One-line change (+ explanatory comment).

## Verification
Eval'd the exact query the way Grafana runs it (range=true, then reduce-last), not the two halves separately:
- **Fresh** → single `{}` series, all `48` → `lt 1` false → **no fire** ✅
- **Stale / absent** → `0` → fires ✅
- `npm test` 5/5 pass; `npm run build` emits the `sum(...)` expr.

## After merge
CI (`grafana-dashboard.yml`) redeploys the group on merge to `main`, overwriting the live rule with the fixed query, which resolves the false alert on the next eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)