### PR TITLE
fix(grafana): stop flaky Volvo stale-alert pages on datasource blips

### DIFF
--- a/grafana/src/alerts/volvo-metrics-stale.ts
+++ b/grafana/src/alerts/volvo-metrics-stale.ts
@@ -21,6 +21,13 @@ import { reduceExpr, thresholdExpr, vmAlertQuery } from './helpers.ts';
  * rule fires even when data is fresh. `sum` collapses the count to a single
  * `{}` series that shares vector(0)'s label set, so `or` drops the fallback
  * whenever real data exists.
+ *
+ * `noData`/`execErr` are both `KeepLast`, not `Alerting`/`Error`. Grafana Cloud
+ * reaches this VM datasource directly over the internet (home rpi5 behind
+ * Caddy), so brief network blips surface as transient DatasourceError/NoData
+ * and would otherwise page on every flake. Real staleness is signalled by the
+ * `count = 0` *value* (never by an error or empty frame, thanks to vector(0)),
+ * so holding the last state through a transient error can't mask it.
  */
 export function volvoMetricsStale(): alerting.RuleBuilder {
   return new alerting.RuleBuilder('Volvo XC40 data saknas')
@@ -28,8 +35,8 @@ export function volvoMetricsStale(): alerting.RuleBuilder {
     .ruleGroup('Irisgatan')
     .condition('C')
     .forDuration('0s')
-    .noDataState('Alerting')
-    .execErrState('Error')
+    .noDataState('KeepLast')
+    .execErrState('KeepLast')
     .annotations({
       __dashboardUid__: 'irisgatan-v3',
       __panelId__: '44',


### PR DESCRIPTION
## Problem
After the phantom-series fix (#415), the Volvo staleness rule started paging with **`DatasourceError`** — firing, then self-resolving a few minutes later (`B=-1, C=-1` while erroring → `B=47, C=0` on recovery). It's flaky, not a real stale condition.

## Root cause
Grafana Cloud (`irisgatan.grafana.net`) evaluates this rule against the **home VM datasource over the internet** (rpi5 behind Caddy). Brief network blips surface as a transient `DatasourceError`, and the rule had `execErrState: Error` (+ `noDataState: Alerting`), so **every blip paged**. The query itself is fine — 8/8 clean when hammered through the proxy, and the rule sits `inactive/health ok` between blips.

## Fix
Set both `noDataState` and `execErrState` to **`KeepLast`**: a transient error or empty frame holds the previous state instead of flipping to firing.

This is safe because real staleness is signalled by the **`count = 0` value**, never by an error or empty frame — `sum(count_over_time(...)) or vector(0)` always returns a concrete number. So holding last-state through a blip cannot mask a genuine 4h gap; once data is truly absent for 4h the value goes to 0 and the threshold fires normally.

## Test
- `npm test` 5/5 pass.
- Build confirms `noDataState=KeepLast`, `execErrState=KeepLast`, `for=0s`.
- Deploys via `grafana-dashboard.yml` on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)