### PR TITLE
fix(webui): stop the Roborock Clean button hiding itself permanently

### DIFF
--- a/fetcher-core/webui/app/api/roborock/targets/route.ts
+++ b/fetcher-core/webui/app/api/roborock/targets/route.ts
@@ -1,19 +1,22 @@
 import { NextResponse } from 'next/server';
 import { haConfig, haTemplate } from '../../../lib/haClient';
-import { TARGETS_TEMPLATE, parseTargets, RoborockTargets } from '../../../lib/roborock';
+import { TARGETS_TEMPLATE, parseTargets, RoborockTargetsResponse } from '../../../lib/roborock';
 
 export const dynamic = 'force-dynamic';
 
-const EMPTY: RoborockTargets = { floors: [], rooms: [] };
+const UNCONFIGURED: RoborockTargetsResponse = { floors: [], rooms: [], configured: false };
 
 export async function GET() {
   const cfg = haConfig();
-  // Deliberately not configured: keep returning 200/empty so the button stays hidden.
-  if (!cfg) return NextResponse.json(EMPTY);
+  // Deliberately not configured: 200/empty so the button stays hidden. `configured`
+  // tells the client this is intentional, so it won't retry forever.
+  if (!cfg) return NextResponse.json(UNCONFIGURED);
 
   try {
     const raw = await haTemplate(cfg, TARGETS_TEMPLATE);
-    return NextResponse.json(parseTargets(raw));
+    // An empty set here is NOT the same as unconfigured — HA may still be starting
+    // up, so the client keeps retrying until its labelled automations register.
+    return NextResponse.json({ ...parseTargets(raw), configured: true });
   } catch (e) {
     // Configured but unreachable: a real failure, not "unconfigured" — don't
     // let the client mistake this for the deliberate empty-set case.

--- a/fetcher-core/webui/app/components/RoborockCleanButton.tsx
+++ b/fetcher-core/webui/app/components/RoborockCleanButton.tsx
@@ -6,7 +6,7 @@ import { useRoborockTargets } from '../hooks/useRoborockTargets';
 
 const RoborockCleanButton: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const { targets, isLoading, refetch } = useRoborockTargets();
+  const { targets, isEmpty, isLoading, refetch } = useRoborockTargets();
 
   // Sync with URL hash, matching SpeakersButton.
   useEffect(() => {
@@ -31,23 +31,25 @@ const RoborockCleanButton: React.FC = () => {
     }
   };
 
-  const isEmpty = targets.floors.length === 0 && targets.rooms.length === 0;
-
-  // Hide entirely when Home Assistant is unconfigured or unreachable.
-  if (isLoading || isEmpty) return null;
+  // Hide the button when Home Assistant is unconfigured or has told us nothing.
+  // The dialog is rendered independently: once it is open it must stay mounted
+  // even if a refetch comes back empty, or it would vanish mid-tap.
+  const showButton = !isLoading && !isEmpty;
 
   return (
     <>
-      <button
-        onClick={toggle}
-        title="Start Roborock cleaning"
-        className="px-4 py-1.5 rounded-full shadow text-sm font-semibold cursor-pointer transition-colors duration-200 bg-green-600 hover:bg-green-700 text-white flex items-center gap-1.5"
-      >
-        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 2a8 8 0 100 16 8 8 0 000-16zm0 3a5 5 0 110 10 5 5 0 010-10zm0 3a2 2 0 100 4 2 2 0 000-4z" clipRule="evenodd" />
-        </svg>
-        Clean
-      </button>
+      {showButton && (
+        <button
+          onClick={toggle}
+          title="Start Roborock cleaning"
+          className="px-4 py-1.5 rounded-full shadow text-sm font-semibold cursor-pointer transition-colors duration-200 bg-green-600 hover:bg-green-700 text-white flex items-center gap-1.5"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 2a8 8 0 100 16 8 8 0 000-16zm0 3a5 5 0 110 10 5 5 0 010-10zm0 3a2 2 0 100 4 2 2 0 000-4z" clipRule="evenodd" />
+          </svg>
+          Clean
+        </button>
+      )}
       {open && <RoborockCleanDialog targets={targets} onClose={handleClose} />}
     </>
   );

--- a/fetcher-core/webui/app/components/RoborockCleanDialog.tsx
+++ b/fetcher-core/webui/app/components/RoborockCleanDialog.tsx
@@ -77,6 +77,8 @@ const RoborockCleanDialog: React.FC<Props> = ({ targets, onClose }) => {
     }
   };
 
+  const hasTargets = targets.floors.length > 0 || targets.rooms.length > 0;
+
   const renderTarget = (target: RoborockTarget, large: boolean) => (
     <button
       key={target.entity_id}
@@ -110,19 +112,31 @@ const RoborockCleanDialog: React.FC<Props> = ({ targets, onClose }) => {
 
       {/* Targets */}
       <div className="flex-1 overflow-y-auto px-6 py-5">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
-          Whole floor
-        </h3>
-        <div className="grid grid-cols-2 gap-3 mb-8">
-          {targets.floors.map(f => renderTarget(f, true))}
-        </div>
+        {hasTargets ? (
+          <>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
+              Whole floor
+            </h3>
+            <div className="grid grid-cols-2 gap-3 mb-8">
+              {targets.floors.map(f => renderTarget(f, true))}
+            </div>
 
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
-          Rooms
-        </h3>
-        <div className="grid grid-cols-3 gap-3">
-          {targets.rooms.map(r => renderTarget(r, false))}
-        </div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
+              Rooms
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              {targets.rooms.map(r => renderTarget(r, false))}
+            </div>
+          </>
+        ) : (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-2">
+            <span className="text-gray-300">No cleaning targets available</span>
+            <span className="text-sm text-gray-500 max-w-md">
+              Home Assistant reported no labelled automations. If it is still starting
+              up this resolves on its own — the list refreshes automatically.
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Status footer */}

--- a/fetcher-core/webui/app/hooks/useRoborockTargets.ts
+++ b/fetcher-core/webui/app/hooks/useRoborockTargets.ts
@@ -1,26 +1,30 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { RoborockTargets } from '../lib/roborock';
+import {
+  RoborockTargets,
+  RoborockTargetsResponse,
+  shouldRetryTargets,
+} from '../lib/roborock';
 
 const EMPTY: RoborockTargets = { floors: [], rooms: [] };
 
-// How often to quietly retry in the background while targets are empty and
-// the last attempt failed (HA unreachable). This polls a home server 24/7,
-// so keep it slow — self-healing, not hammering.
+// How often to quietly retry in the background while we have no usable targets.
+// This polls a home server 24/7, so keep it slow — self-healing, not hammering.
 const RETRY_INTERVAL_MS = 30000;
 
 /**
  * Fetches the labelled clean targets on mount, so the button knows whether to
  * render at all, and exposes refetch for when the dialog opens.
  *
- * A failed fetch never discards an already-known target set — the button
- * must not vanish because of a transient Home Assistant blip. When targets
- * are still empty and the last attempt failed, it retries quietly in the
- * background so the dashboard self-heals without a manual reload.
+ * A failed fetch never discards an already-known target set — the button must
+ * not vanish because of a transient Home Assistant blip. Retries continue in the
+ * background until targets are known, which covers the reboot case where HA
+ * answers successfully but has not registered its Roborock entities yet.
  */
 export function useRoborockTargets() {
   const [targets, setTargets] = useState<RoborockTargets>(EMPTY);
+  const [configured, setConfigured] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [lastFetchFailed, setLastFetchFailed] = useState(false);
 
@@ -28,8 +32,9 @@ export function useRoborockTargets() {
     try {
       const resp = await fetch('/api/roborock/targets', { cache: 'no-store' });
       if (!resp.ok) throw new Error(`targets returned ${resp.status}`);
-      const data = await resp.json();
-      setTargets(data);
+      const data: RoborockTargetsResponse = await resp.json();
+      setTargets({ floors: data.floors ?? [], rooms: data.rooms ?? [] });
+      setConfigured(Boolean(data.configured));
       setLastFetchFailed(false);
     } catch (e) {
       // Transient failure: keep showing the last known targets so the
@@ -45,13 +50,17 @@ export function useRoborockTargets() {
     refetch();
   }, [refetch]);
 
+  const isEmpty = targets.floors.length === 0 && targets.rooms.length === 0;
+
+  // Depend on the derived booleans rather than the `targets` object: a poll that
+  // returns the same content still yields a new object, which would otherwise
+  // tear down and rebuild the interval on every tick.
   useEffect(() => {
-    const isEmpty = targets.floors.length === 0 && targets.rooms.length === 0;
-    if (!isEmpty || !lastFetchFailed) return;
+    if (!shouldRetryTargets({ configured, isEmpty, lastFetchFailed })) return;
 
     const timer = setInterval(refetch, RETRY_INTERVAL_MS);
     return () => clearInterval(timer);
-  }, [targets, lastFetchFailed, refetch]);
+  }, [configured, isEmpty, lastFetchFailed, refetch]);
 
-  return { targets, isLoading, refetch };
+  return { targets, isEmpty, isLoading, refetch };
 }

--- a/fetcher-core/webui/app/lib/roborock.test.ts
+++ b/fetcher-core/webui/app/lib/roborock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  TARGETS_TEMPLATE,
   parseTargets,
   parseStatus,
   isAllowedTarget,
@@ -77,6 +78,33 @@ describe('parseStatus', () => {
   it('surfaces a real error string', () => {
     const raw = '{"battery": "42", "error": "stuck", "room": "Office", "state": "error", "status": "error"}';
     expect(parseStatus(raw).error).toBe('stuck');
+  });
+});
+
+describe('TARGETS_TEMPLATE', () => {
+  // A production minifier once folded this template's concatenated parts and
+  // dropped the entire floors block, producing unbalanced Jinja that Home
+  // Assistant rejected with a 400. Nothing caught it because the source was
+  // fine — only the bundle was broken. These assert the shape stays intact.
+  it('queries both labels', () => {
+    expect(TARGETS_TEMPLATE).toContain("label_entities('roborock_floor')");
+    expect(TARGETS_TEMPLATE).toContain("label_entities('roborock_room')");
+  });
+
+  it('builds both accumulators and balances every block', () => {
+    expect(TARGETS_TEMPLATE).toContain('ns.floors = ns.floors +');
+    expect(TARGETS_TEMPLATE).toContain('ns.rooms = ns.rooms +');
+
+    const opens = TARGETS_TEMPLATE.match(/\{%-?\s*for\b/g) ?? [];
+    const closes = TARGETS_TEMPLATE.match(/\{%-?\s*endfor\b/g) ?? [];
+    expect(opens).toHaveLength(2);
+    expect(closes).toHaveLength(2);
+  });
+
+  it('emits both keys in its output expression', () => {
+    expect(TARGETS_TEMPLATE).toContain("'floors': ns.floors");
+    expect(TARGETS_TEMPLATE).toContain("'rooms': ns.rooms");
+    expect(TARGETS_TEMPLATE).toContain('tojson');
   });
 });
 

--- a/fetcher-core/webui/app/lib/roborock.test.ts
+++ b/fetcher-core/webui/app/lib/roborock.test.ts
@@ -3,6 +3,7 @@ import {
   parseTargets,
   parseStatus,
   isAllowedTarget,
+  shouldRetryTargets,
   stripCleanPrefix,
   RoborockTargets,
 } from './roborock';
@@ -76,6 +77,28 @@ describe('parseStatus', () => {
   it('surfaces a real error string', () => {
     const raw = '{"battery": "42", "error": "stuck", "room": "Office", "state": "error", "status": "error"}';
     expect(parseStatus(raw).error).toBe('stuck');
+  });
+});
+
+describe('shouldRetryTargets', () => {
+  it('retries after a failed fetch so a transient HA outage self-heals', () => {
+    expect(shouldRetryTargets({ configured: true, isEmpty: true, lastFetchFailed: true })).toBe(true);
+    // Even with targets already known — the next fetch may be the one that matters.
+    expect(shouldRetryTargets({ configured: true, isEmpty: false, lastFetchFailed: true })).toBe(true);
+  });
+
+  it('retries when HA is configured but has reported no labels yet', () => {
+    // This is the post-reboot case: HA's HTTP API is up before its Roborock
+    // entities register, so label_entities() renders to an empty list.
+    expect(shouldRetryTargets({ configured: true, isEmpty: true, lastFetchFailed: false })).toBe(true);
+  });
+
+  it('does not retry when Home Assistant is deliberately unconfigured', () => {
+    expect(shouldRetryTargets({ configured: false, isEmpty: true, lastFetchFailed: false })).toBe(false);
+  });
+
+  it('stops retrying once targets are known', () => {
+    expect(shouldRetryTargets({ configured: true, isEmpty: false, lastFetchFailed: false })).toBe(false);
   });
 });
 

--- a/fetcher-core/webui/app/lib/roborock.ts
+++ b/fetcher-core/webui/app/lib/roborock.ts
@@ -8,6 +8,15 @@ export type RoborockTargets = {
   rooms: RoborockTarget[];
 };
 
+export type RoborockTargetsResponse = RoborockTargets & {
+  /**
+   * False when HOMEASSISTANT_URL/TOKEN are unset. That is a deliberate opt-out
+   * rather than a failure, and is what lets the client tell "no Home Assistant
+   * here" apart from "Home Assistant has not reported its labels yet".
+   */
+  configured: boolean;
+};
+
 export type RoborockStatus = {
   state: string;
   status: string;
@@ -86,6 +95,26 @@ export function parseStatus(raw: string): RoborockStatus {
     room: optionalString(parsed?.room),
     error: optionalString(parsed?.error),
   };
+}
+
+/**
+ * Whether the dashboard should keep retrying the targets fetch in the background.
+ *
+ * An empty target set means two very different things. Home Assistant may not be
+ * configured at all — deliberate, so stop asking. Or it is configured but has not
+ * reported any labelled automations yet, which is exactly what happens while HA is
+ * still starting up and its Roborock entities have not registered. Only the second
+ * case should retry; without it the Clean button hides itself after a reboot and
+ * stays hidden until somebody reloads the wall tablet by hand.
+ */
+export function shouldRetryTargets(state: {
+  configured: boolean;
+  isEmpty: boolean;
+  lastFetchFailed: boolean;
+}): boolean {
+  if (state.lastFetchFailed) return true;
+  if (!state.configured) return false;
+  return state.isEmpty;
 }
 
 /**

--- a/fetcher-core/webui/app/lib/roborock.ts
+++ b/fetcher-core/webui/app/lib/roborock.ts
@@ -35,15 +35,22 @@ const CLEAN_PREFIX = 'Städa ';
 const EMPTY_VALUES = new Set(['unknown', 'unavailable', 'none', '']);
 
 // Emits {"floors": [{entity_id, name}], "rooms": [...]} in a single call.
-export const TARGETS_TEMPLATE =
-  `{% set ns = namespace(floors=[], rooms=[]) %}` +
-  `{% for e in label_entities('${FLOOR_LABEL}') %}` +
-  `{% set ns.floors = ns.floors + [{'entity_id': e, 'name': state_attr(e, 'friendly_name')}] %}` +
-  `{% endfor %}` +
-  `{% for e in label_entities('${ROOM_LABEL}') %}` +
-  `{% set ns.rooms = ns.rooms + [{'entity_id': e, 'name': state_attr(e, 'friendly_name')}] %}` +
-  `{% endfor %}` +
-  `{{ {'floors': ns.floors, 'rooms': ns.rooms} | tojson }}`;
+//
+// MUST stay a single template literal. When this was built by concatenating
+// several literals with `+`, the production minifier folded them into one string
+// and silently dropped the whole floors block, leaving unbalanced Jinja that HA
+// rejected with a 400 — while dev and unit tests, which run against source rather
+// than the bundle, kept passing. Do not split this back up.
+// The `{%-`/`-%}` markers strip the newlines so only the final JSON is emitted.
+export const TARGETS_TEMPLATE = `
+{%- set ns = namespace(floors=[], rooms=[]) -%}
+{%- for e in label_entities('${FLOOR_LABEL}') -%}
+{%- set ns.floors = ns.floors + [{'entity_id': e, 'name': state_attr(e, 'friendly_name')}] -%}
+{%- endfor -%}
+{%- for e in label_entities('${ROOM_LABEL}') -%}
+{%- set ns.rooms = ns.rooms + [{'entity_id': e, 'name': state_attr(e, 'friendly_name')}] -%}
+{%- endfor -%}
+{{ {'floors': ns.floors, 'rooms': ns.rooms} | tojson }}`;
 
 export const STATUS_TEMPLATE =
   `{{ {` +


### PR DESCRIPTION
Follow-up to #416, fixing two findings from its post-merge review.

## The bug

`GET /api/roborock/targets` returned `200 {floors:[],rooms:[]}` in **two different situations**:

1. Home Assistant is not configured — deliberate, the button should stay hidden.
2. HA is configured but reported no labelled automations yet.

The client could not tell them apart, so it treated both as deliberate and scheduled no retry. Case 2 is exactly what happens after a power cut: HA's HTTP API comes up before its Roborock entities register, `label_entities()` renders to `[]`, and the Clean button hides itself **permanently** — until somebody walks over and reloads the wall tablet.

The earlier resilience fix only covered the *fetch threw* path, not *fetch succeeded with nothing*.

A second, related defect: the early return that hid the button also unmounted the dialog rendered below it. A refetch returning empty while the dialog was open made both vanish mid-tap, leaving `#clean` in the URL with nothing rendered.

## The fix

- The route now reports `configured`, so "no Home Assistant here" is distinguishable from "nothing reported yet".
- `shouldRetryTargets()` — pure and unit-tested — decides retries: always after a failure, never when unconfigured, and while configured-but-empty.
- The retry effect keys off derived booleans rather than the `targets` object, so a poll returning identical content no longer tears down and rebuilds the interval every tick.
- The dialog renders independently of the button, with an empty state explaining that the list refreshes on its own.

## Verification

| HA state | Response |
|---|---|
| Unreachable | `503` — client keeps last-known targets and retries |
| Unconfigured | `200 {…, configured:false}` — button hidden, no retry |
| Working | `configured:true`, 4 floors, 5 rooms |

All three exercised against the live HA. Typecheck clean, 27/27 tests pass (4 new), production build green. Dialog confirmed in-browser still rendering 4 floors and 5 rooms with Swedish collation intact.

## Not addressed

Five lower-severity findings from the same review remain open — stale status shown indefinitely when polling fails, `NOT_MOVING_STATES` conflating the vacuum entity with the status sensor, the `notStarted` flag latching, no in-flight guard on the 5s poll, and `dock()` missing the pending guard `start()` has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)