### PR TITLE
Make the Reload button icon-only

### DIFF
--- a/fetcher-core/webui/app/components/RefreshBadge.tsx
+++ b/fetcher-core/webui/app/components/RefreshBadge.tsx
@@ -9,12 +9,12 @@ const RefreshBadge: React.FC = () => {
     <button
       onClick={reloadPage}
       title="Reload page"
-      className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 rounded-full shadow text-sm font-semibold cursor-pointer flex items-center gap-1.5"
+      aria-label="Reload page"
+      className="bg-blue-600 hover:bg-blue-700 text-white w-9 h-9 rounded-full shadow cursor-pointer flex items-center justify-center transition-colors"
     >
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
       </svg>
-      Reload
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- Drops the "Reload" text label from the header's reload button, keeping just the refresh icon in a circular button.
- Sized to match the height of the other header pill buttons (Speakers, Pomodoro) so the row stays visually aligned.
- Frees up horizontal space in the header row, which is tight on phone widths (see the recent mobile layout overflow fixes in #424).

## Test plan
- [x] `npm run build` and `npx vitest run` pass in `fetcher-core/webui`.
- [x] Verified visually with a local dev server screenshot at a phone viewport width — button renders as a compact circle with just the icon.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRo5joH6JxdftpzWQEEHZ4)_