### PR TITLE
fix(https-proxy): allow VPN subnet and stop duplicate HA security headers

### DIFF
--- a/https-proxy/Dockerfile
+++ b/https-proxy/Dockerfile
@@ -77,6 +77,11 @@ cat > /etc/caddy/Caddyfile <<'CADDYFILE'
 	abort @denied
 
 	header {
+		# Apply after the upstream response headers are written, otherwise
+		# Home Assistant's own X-Frame-Options / X-Content-Type-Options are
+		# appended alongside ours and each is sent twice.
+		defer
+
 		X-Frame-Options "SAMEORIGIN"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"

--- a/https-proxy/Dockerfile
+++ b/https-proxy/Dockerfile
@@ -73,7 +73,7 @@ cat > /etc/caddy/Caddyfile <<'CADDYFILE'
 }
 
 {$HA_DOMAIN} {
-	@denied not remote_ip 192.168.68.0/24 185.176.29.48
+	@denied not remote_ip 192.168.68.0/24 10.8.0.0/24 185.176.29.48
 	abort @denied
 
 	header {


### PR DESCRIPTION
## What

Two fixes to the `{$HA_DOMAIN}` site block in `https-proxy/Dockerfile`:

1. Add the OpenVPN client subnet `10.8.0.0/24` to the IP allowlist.
2. Add `defer` to the `header` block so the security headers stop being sent twice.

## Why

### 1. VPN clients were blocked

`ha.filiplindqvist.com` was unreachable for clients connected over the home OpenVPN. The router hands VPN clients addresses in `10.8.0.0/24`, and Caddy sees that real client IP (Docker DNAT preserves it), so every VPN request failed the `@denied not remote_ip ...` matcher and hit `abort`.

The failure mode was misleading: `abort` tears the connection down without a response, so curl reports `HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)` rather than a 403. That reads like a TLS or proxy fault, not an access-control decision.

Confirmed the source IP by reading the peer address from `/proc/net/tcp*` inside the `https-proxy` container while issuing requests — the HA site block has no `log` directive, so denied requests leave no access-log entry, and `tcpdump` isn't installed on rpi5.

### 2. Duplicate security headers

`X-Frame-Options` and `X-Content-Type-Options` were each present twice in every response. Per the [Caddy `header` docs](https://caddyserver.com/docs/caddyfile/directives/header), a plain `header Foo bar` executes immediately; `reverse_proxy` then writes Home Assistant's own headers on top, so both values survive. `defer` postpones the operations until the response is written, making Caddy's values authoritative.

`defer` was chosen over the per-field `>` prefix because it is one line and any header added to the block later inherits the correct behavior. The `?` prefix was rejected — it only sets when absent, which would let the upstream win.

## Verification

Image built, pushed, and deployed to rpi5 after each change. `caddy fmt` runs during the build, so Caddyfile syntax is validated there.

- `curl https://ha.filiplindqvist.com/` → **200**, serving the Home Assistant frontend (`<title>Home Assistant</title>`) over HTTP/2 with a valid public cert
- Previously: aborted connection for any VPN client
- `x-frame-options` and `x-content-type-options` now appear **exactly once** each (verified by header count); HSTS and `x-xss-protection` values unchanged
- `ai.filiplindqvist.com` unaffected (307), `https-proxy` healthy

## Notes for reviewers

- Scope of the allowlist change: this widens access to any client on the VPN subnet. Since obtaining a `10.8.0.x` address requires authenticating to the router's OpenVPN server, this is equivalent in trust to being on the LAN.
- Requests arriving via the **public** WAN path still hit `abort`, because they carry the client's public IP rather than a VPN address. That is unchanged and intentional. Reaching the domain from a VPN client requires the name to resolve to the LAN IP (handled client-side, e.g. `/etc/hosts`), because the router's OpenVPN pushes `10.8.0.1` as the resolver while its DNS is bound to the LAN interface only — so VPN DNS falls through to the secondary and returns the WAN address.
- `X-XSS-Protection` is deprecated and ignored by current browsers. Left as-is to keep this PR scoped.
