### PR TITLE
webui: source "Pool Temperatur" from heat pump inlet temp

### DIFF
--- a/fetcher-core/webui/app/lib/values.ts
+++ b/fetcher-core/webui/app/lib/values.ts
@@ -10,7 +10,9 @@ export const values: Config = [
     ],
     [
         { measurement: 'spa_climate', field: 'current_temperature_value', title: '🛁 Spa Temperatur', unit: '°C', sparkline: '24h', sparklineMin: 0, sparklineMax: 45 },
-        { measurement: 'pool_temperature', field: 'value', title: '🏊 Pool Temperatur', unit: '°C', sparkline: '24h', sparklineMin: 0, sparklineMax: 30 },
+        // Poolens Sonoff-givare (pool_temperature_value) är trasig och rapporterar 0 °C.
+        // Visa ingående vattentemperatur till poolvärmepumpen istället tills givaren bytts ut.
+        { measurement: 'aqua_temp', field: 'temp_incoming', title: '🏊 Pool Temperatur', unit: '°C', sparkline: '24h', sparklineMin: 0, sparklineMax: 35 },
         { measurement: 'pool_iqpump_motordata', field: 'speed', title: '💦 Poolpump', unit: 'RPM', decimals: 0, sparkline: '24h', sparklineMin: 0, sparklineMax: 3000 },
     ],
     [


### PR DESCRIPTION
## Problem

The Sonoff pool sensor is broken and reports 0 °C, so the "🏊 Pool Temperatur" tile in the webui reads zero. The sensor is due to be replaced.

## Change

`fetcher-core/webui/app/lib/values.ts`: the tile now reads the pool heat pump's **incoming water temperature** instead of the dead sensor.

| | before | after |
|---|---|---|
| measurement / field | `pool_temperature` / `value` | `aqua_temp` / `temp_incoming` |
| selector | `pool_temperature_value` | `aqua_temp_temp_incoming` |
| `sparklineMax` | 30 | 35 |

`aqua_temp_temp_incoming` is the same series the Grafana "Vattentemperatur - Poolvärmepump" panel plots as "Ingående" — water leaving the pool on its way into the heat pump, which is the closest available stand-in for pool temperature. It's written by the `aquatemp` module (`fetcher-core/python/src/aquatemp.py`, protocol code `T02`) every 5 minutes, comfortably inside the tile's 15 m `last_over_time` lookback. A comment in `values.ts` records why the swap was made so it can be reverted once the new sensor is in.

Sparkline max raised 30 → 35 °C so readings near the old ceiling aren't clipped.

Nothing else references `pool_temperature` in the webui. The Grafana dashboard and `pool-pump-planner` still use `pool_temperature_value` and are untouched — say the word if you want those switched over too.

## Caveat

Unlike the Sonoff sensor, the heat pump only reports while it is powered and reachable. When it's off (e.g. over winter) the tile will go blank rather than show a stale or zero value.

## Testing

- `npm run typecheck` — clean
- `npm test` — 36/36 passing

Not verified against live VictoriaMetrics: this session has no VM credentials (`scripts/vm-query.sh` can't resolve an endpoint/token here), so the metric name comes from the writer code and the existing Grafana panels rather than a live query.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHArMmVWZaiw2gMcp6QdQs)_