### PR TITLE
Add auto-merge skill and gh-automerge.sh

### DIFF
--- a/.claude/skills/auto-merge/SKILL.md
+++ b/.claude/skills/auto-merge/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: auto-merge
+description: Watch a pull request's CI checks and merge it as soon as they're all green. Use this whenever the user wants a PR merged after CI passes rather than right now — "merge when green", "merge it when CI passes", "auto-merge this", "merge when done", "keep an eye on the PR and land it", or just "merged when done" after you've opened a PR. This repo is private on a free GitHub plan, so GitHub's own auto-merge button does not exist here and `enable_pr_auto_merge` will fail — this skill is the replacement. Also use it when a PR needs babysitting to green before landing.
+allowed-tools: Bash, mcp__github__pull_request_read, mcp__github__merge_pull_request, mcp__github__list_pull_requests, mcp__github__unsubscribe_pr_activity
+---
+
+# Auto-merge a PR when CI goes green
+
+GitHub's native auto-merge is a paid feature for private repos, so it isn't
+available on this one. `enable_pr_auto_merge` will fail here — don't reach for
+it. Instead, watch the checks and merge yourself once they pass.
+
+There are two ways to do that, and which one you use depends on whether `gh`
+can actually reach the repo from wherever you're running.
+
+## Pick a lane
+
+Just run the script. It tells you within a second if `gh` can't get through:
+
+```bash
+./scripts/gh-automerge.sh <pr-number>          # or no argument for the current branch
+```
+
+- **Exit 10 with "gh can't reach this repo"** → you're in a Claude Code remote
+  or web session, where GitHub is only reachable through the MCP tools even
+  though the `gh` binary exists and `gh auth status` looks plausible. Use
+  **Lane B**.
+- **Anything else** → `gh` works. Use **Lane A**.
+
+## Lane A — `gh` works (local machine, rpi5)
+
+Run the script in the background and let it do the whole job. It polls, merges
+when green, and exits with a code that says what happened:
+
+```bash
+./scripts/gh-automerge.sh 441 --interval 60
+```
+
+Use `run_in_background: true` — this can legitimately run for an hour, and you
+get one notification when it finishes rather than a turn per poll. Read the
+output file when it completes and report the verdict.
+
+Options worth knowing: `--method merge|rebase` (default `squash`, which matches
+this repo's linear `title (#N)` history), `--interval`, `--timeout`,
+`--keep-branch`, `--allow-no-checks`. `--help` lists everything.
+
+Exit codes: `0` merged · `2` a check failed · `3` conflict · `4` blocked by
+review · `5` GitHub refused · `6` timed out · `7` draft · `8` no checks ·
+`9` not open · `10` setup problem.
+
+Nothing was merged for any non-zero code, so each one needs a decision from
+you, not a silent retry.
+
+## Lane B — MCP only (Claude Code on the web / remote sessions)
+
+Same logic, driven by hand. The loop per poll:
+
+1. `mcp__github__pull_request_read` with `method: "get_check_runs"` — every run
+   needs `status: "completed"`. Treat `success`, `neutral` and `skipped` as
+   passing; anything else (`failure`, `cancelled`, `timed_out`,
+   `action_required`) is a failure.
+2. If checks are still running, wait and poll again. Foreground `sleep` is
+   blocked in this harness, so pace yourself with a background tick:
+   `Bash("sleep 90", run_in_background: true)` — the completion notification
+   wakes you for the next poll. Start at 60s and ease out toward ~3 min
+   (60 → 90 → 120 → 150 → 180); a typical build here takes ~9 minutes, so
+   tight polling just burns turns.
+3. When everything is complete and passing, check `method: "get"` for
+   `draft`, `mergeable`/`mergeable_state`, and review state before merging.
+4. Merge with `mcp__github__merge_pull_request`, `merge_method: "squash"`,
+   `commit_title: "<PR title> (#<number>)"`.
+
+## What must stop the merge
+
+These are the reasons the script exits non-zero, and they apply just as much in
+Lane B. The point of an auto-merge helper is to save waiting, not to lower the
+bar for landing code:
+
+- **A failing check.** Report which one and link the job. Diagnose it — the fix
+  is a commit, not a re-run. Re-running is only right when the job died before
+  any test body executed (checkout, dependency install, lost runner), and never
+  a way to shake loose a real failure. Never skip or disable a test to get green.
+- **A draft PR.** Mark it ready first, deliberately.
+- **A merge conflict.** Merge the base branch in, resolve, push, and let CI
+  re-run before merging.
+- **Changes requested, or a required approval that isn't there.** That's a
+  human's call.
+- **No checks at all.** Usually means the workflow hasn't registered yet, not
+  that the PR is safe. The script waits three polls, then refuses; only pass
+  `--allow-no-checks` when you know the repo genuinely has no CI for that path.
+
+## After it merges
+
+- Report the squash SHA and that CI was green when it landed.
+- If the session was watching the PR, `mcp__github__unsubscribe_pr_activity`
+  and delete any scheduled check-in Routine you created for it — the merge
+  notice makes both obsolete.
+- Deployment isn't automatic. Merging only lands the change on `main`; getting
+  it onto rpi5 is a separate step (see the `rpi5` skill).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,5 +21,9 @@ For anything involving metrics, PromQL, or series shape, use the `victoria-metri
 - In Grafana dashboards, use `$__interval` with `spanNulls` instead of hardcoded lookback windows
 - Update the Grafana dashboard via the conversion script (`convert_dashboard.py`), not by editing JSON directly
 
+# Pull requests
+- GitHub's native auto-merge is unavailable (private repo, free plan) — `enable_pr_auto_merge` will fail. To land a PR once CI passes, use the `auto-merge` skill / `scripts/gh-automerge.sh`.
+- `main` is squash-only, linear history: `title (#N)`.
+
 # CI / GitHub Actions
 - To suppress actionlint warnings, use `.github/actionlint.yaml` with an `ignore:` pattern — inline comments like `# actionlint:ignore:rule` don't work

--- a/scripts/gh-automerge.sh
+++ b/scripts/gh-automerge.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Poll a pull request's CI checks and merge it as soon as they're all green.
+#
+# Stands in for GitHub's native auto-merge, which isn't available on private
+# repos under the free plan. Run it in the background and forget about it —
+# it prints one line per state change and a final verdict, then exits with a
+# code that says what happened (see EXIT CODES below).
+set -uo pipefail
+
+INTERVAL=60
+TIMEOUT=3600
+METHOD=squash
+DELETE_BRANCH=--delete-branch
+ALLOW_NO_CHECKS=false
+PR=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [<pr-number-or-url>] [options]
+
+Polls the PR's checks and merges when every one has passed. With no PR
+argument, uses the PR for the current branch.
+
+Options:
+  --method <squash|merge|rebase>  Merge method (default: squash)
+  --interval <seconds>            Poll interval (default: 60)
+  --timeout <seconds>             Give up after this long (default: 3600)
+  --keep-branch                   Don't delete the head branch after merging
+  --allow-no-checks               Merge even if the PR has no CI checks at all
+  -h, --help                      Show this help
+
+Exit codes:
+  0  merged
+  2  a check failed — nothing was merged
+  3  merge conflict with the base branch
+  4  blocked by review (changes requested, or an approval is required)
+  5  GitHub refused the merge for some other reason
+  6  timed out while checks were still running
+  7  PR is a draft — mark it ready first
+  8  PR has no checks (pass --allow-no-checks to merge anyway)
+  9  PR isn't open (already merged or closed)
+ 10  setup problem (no gh, not authenticated, or no PR found)
+
+Examples:
+  $(basename "$0")                    # PR for the current branch
+  $(basename "$0") 441                # a specific PR
+  $(basename "$0") 441 --interval 30  # poll more often
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --method)          METHOD="$2"; shift 2 ;;
+    --interval)        INTERVAL="$2"; shift 2 ;;
+    --timeout)         TIMEOUT="$2"; shift 2 ;;
+    --keep-branch)     DELETE_BRANCH=""; shift ;;
+    --allow-no-checks) ALLOW_NO_CHECKS=true; shift ;;
+    -h|--help)         usage; exit 0 ;;
+    -*)                echo "unknown option: $1" >&2; usage >&2; exit 10 ;;
+    *)                 PR="$1"; shift ;;
+  esac
+done
+
+case "$METHOD" in
+  squash|merge|rebase) ;;
+  *) echo "--method must be squash, merge or rebase (got '$METHOD')" >&2; exit 10 ;;
+esac
+
+log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+command -v gh >/dev/null 2>&1 || {
+  echo "gh CLI not found — install it, or drive the merge through the GitHub MCP tools instead." >&2
+  exit 10
+}
+
+FIELDS='number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup'
+GH_ERR=""
+snapshot=""
+ERRFILE="$(mktemp -t gh-automerge.XXXXXX)"
+trap 'rm -f "$ERRFILE"' EXIT
+
+# Sets the globals `snapshot` and `GH_ERR`. It has to assign them in the
+# caller's shell rather than echoing — `x=$(fetch_pr)` would run the whole
+# function in a subshell and the error text would never make it back out.
+fetch_pr() {
+  GH_ERR=""
+  local out
+  if out=$(gh pr view ${PR:+"$PR"} --json "$FIELDS" 2>"$ERRFILE"); then
+    snapshot="$out"
+    return 0
+  fi
+  GH_ERR="$(cat "$ERRFILE")"
+  return 1
+}
+
+# Don't probe auth separately: a token can satisfy `gh auth status` and even
+# `gh api user` while still being denied on this repo (that's what happens in
+# Claude Code remote sessions). The first real call is the honest test.
+if ! fetch_pr; then
+  if grep -qiE 'not enabled|forbidden|401|403|authentication|gh auth login' <<<"$GH_ERR"; then
+    echo "gh can't reach this repo: ${GH_ERR%%$'\n'*}" >&2
+    echo "Run 'gh auth login', or drive the merge through the GitHub MCP tools instead." >&2
+  else
+    echo "No pull request found${PR:+ for '$PR'} — pass a PR number, or run this from a branch that has one." >&2
+    [[ -n "$GH_ERR" ]] && echo "$GH_ERR" >&2
+  fi
+  exit 10
+fi
+
+PR="$(jq -r .number <<<"$snapshot")"
+log "watching PR #$PR — $(jq -r .title <<<"$snapshot")"
+log "$(jq -r .url <<<"$snapshot")"
+
+# Reduce the check rollup to one line per check: "<state>\t<name>\t<url>".
+# CheckRun entries (Actions) report status+conclusion; StatusContext entries
+# (classic commit statuses, e.g. Netlify) report a single state. NEUTRAL and
+# SKIPPED are deliberately counted as passing — they mean "this check chose
+# not to block", which is how GitHub treats them too.
+ROLLUP_JQ='
+  (.statusCheckRollup // [])[] |
+  if .__typename == "CheckRun" then
+    (if .status != "COMPLETED" then "PENDING"
+     elif (.conclusion | ascii_upcase) as $c
+          | ($c == "SUCCESS" or $c == "NEUTRAL" or $c == "SKIPPED") then "PASS"
+     else "FAIL" end) as $s
+    | [$s, .name, (.detailsUrl // "")]
+  else
+    ((.state // "") | ascii_upcase) as $c
+    | (if $c == "SUCCESS" then "PASS"
+       elif $c == "PENDING" or $c == "EXPECTED" then "PENDING"
+       else "FAIL" end) as $s
+    | [$s, (.context // .name // "status"), (.targetUrl // "")]
+  end | @tsv'
+
+deadline=$(( $(date +%s) + TIMEOUT ))
+no_checks_polls=0
+last_summary=""
+
+# Sleep until the next poll and refresh the snapshot, or give up if that
+# would run past the deadline.
+wait_next() {
+  if (( $(date +%s) + INTERVAL > deadline )); then
+    log "timed out after ${TIMEOUT}s — PR #$PR left unmerged."
+    exit 6
+  fi
+  sleep "$INTERVAL"
+  # A transient API blip shouldn't kill a watch that's been running for an
+  # hour — keep the previous snapshot and try again next lap.
+  fetch_pr || log "couldn't refresh PR state, retrying"
+}
+
+while :; do
+  state=$(jq -r .state <<<"$snapshot")
+  if [[ "$state" != "OPEN" ]]; then
+    log "PR #$PR is $state, not open — nothing to merge."
+    exit 9
+  fi
+
+  if [[ "$(jq -r .isDraft <<<"$snapshot")" == "true" ]]; then
+    log "PR #$PR is a draft — mark it ready for review first."
+    exit 7
+  fi
+
+  checks="$(jq -r "$ROLLUP_JQ" <<<"$snapshot")"
+  total=$(grep -c . <<<"$checks" || true)
+  pending=$(grep -c '^PENDING' <<<"$checks" || true)
+  failed=$(grep -c '^FAIL' <<<"$checks" || true)
+
+  if (( total == 0 )); then
+    if [[ "$ALLOW_NO_CHECKS" == "true" ]]; then
+      log "no checks on this PR; merging anyway (--allow-no-checks)"
+      pending=0; failed=0
+    else
+      # Checks often take a few seconds to register after a push, so don't
+      # bail on the first empty poll.
+      no_checks_polls=$(( no_checks_polls + 1 ))
+      if (( no_checks_polls >= 3 )); then
+        log "PR #$PR has no CI checks after $no_checks_polls polls — refusing to merge blindly."
+        log "Re-run with --allow-no-checks if that's expected for this repo."
+        exit 8
+      fi
+      log "no checks reported yet (poll $no_checks_polls/3)"
+      wait_next
+      continue
+    fi
+  fi
+
+  if (( failed > 0 )); then
+    log "CI failed on PR #$PR — not merging. Failing checks:"
+    grep '^FAIL' <<<"$checks" | while IFS=$'\t' read -r _ name url; do
+      log "  ✗ $name${url:+  $url}"
+    done
+    exit 2
+  fi
+
+  if (( pending == 0 )); then
+    mergeable=$(jq -r .mergeable <<<"$snapshot")
+    merge_state=$(jq -r .mergeStateStatus <<<"$snapshot")
+    review=$(jq -r .reviewDecision <<<"$snapshot")
+
+    if [[ "$mergeable" == "CONFLICTING" || "$merge_state" == "DIRTY" ]]; then
+      log "PR #$PR conflicts with its base branch — resolve the conflicts first."
+      exit 3
+    fi
+    if [[ "$review" == "CHANGES_REQUESTED" || "$review" == "REVIEW_REQUIRED" ]]; then
+      log "PR #$PR is blocked by review ($review)."
+      exit 4
+    fi
+
+    (( total > 0 )) && log "all $total check(s) green — merging (--$METHOD)"
+    if merge_out=$(gh pr merge "$PR" "--$METHOD" $DELETE_BRANCH 2>&1); then
+      log "merged PR #$PR ✓"
+      exit 0
+    fi
+    # UNKNOWN mergeability means GitHub is still computing the merge commit;
+    # that's worth another lap rather than a hard failure.
+    if [[ "$mergeable" == "UNKNOWN" ]]; then
+      log "merge not ready yet (mergeability still being computed), retrying"
+    else
+      log "GitHub refused the merge: $merge_out"
+      exit 5
+    fi
+  else
+    summary="$pending of $total check(s) still running: $(grep '^PENDING' <<<"$checks" | cut -f2 | paste -sd', ' -)"
+    # Only speak up when something actually changed, so a long wait doesn't
+    # bury the interesting lines (and doesn't spam if run under a monitor).
+    if [[ "$summary" != "$last_summary" ]]; then
+      log "$summary"
+      last_summary="$summary"
+    fi
+  fi
+
+  wait_next
+done


### PR DESCRIPTION
## Why

GitHub's native auto-merge is a paid feature for private repos, so it doesn't exist on this one — `enable_pr_auto_merge` always fails. This replaces it: poll a PR's checks, merge when they're green, refuse when they're not.

## What's here

**`scripts/gh-automerge.sh`** — does the whole job in one background process wherever `gh` can reach the repo:

```bash
./scripts/gh-automerge.sh            # PR for the current branch
./scripts/gh-automerge.sh 441 --interval 30
```

It polls the check rollup and squash-merges once every check has passed (`neutral` and `skipped` count as passing, matching GitHub). It refuses to merge on a failed check, a draft PR, a conflict, a blocked review, or a PR with no checks at all — that last one usually means the workflow hasn't registered yet, so it waits three polls before giving up rather than merging blindly. Exit codes distinguish the outcomes (`0` merged, `2` check failed, `3` conflict, `4` review, `5` refused, `6` timeout, `7` draft, `8` no checks, `9` not open, `10` setup), so a caller can act on them instead of parsing text. Output is one line per state change plus a verdict, which keeps it readable after an hour of waiting and usable under a monitor.

**`.claude/skills/auto-merge/SKILL.md`** — triggers on "merge when green", "merge when done", "auto-merge this". It covers two lanes because `gh` is installed but blocked from the API inside Claude Code remote/web sessions (403 at the session proxy, regardless of which token is used): if the script exits 10 with an access error, the skill walks the same logic through the GitHub MCP tools, including the polling cadence to use when foreground `sleep` isn't available.

**`CLAUDE.md`** — a short "Pull requests" section recording that native auto-merge is unavailable and that `main` is squash-only.

## Testing

The script's logic is covered two ways, since this session can't reach the GitHub API:

- **Check classification** — 14 fixture rollups through the exact `jq` program the script uses (extracted from the file, so the test can't drift from it): `CheckRun` vs `StatusContext` shapes, queued/in-progress, lowercase conclusions, `NEUTRAL`/`SKIPPED` as passing, `FAILURE`/`CANCELLED`/`TIMED_OUT`/`ACTION_REQUIRED` as failing, empty and absent rollups.
- **End-to-end** — 13 scenarios against a stub `gh` on `PATH`: green-after-two-polls, failed check, conflict, changes-requested, draft, already-merged, no-access, no-PR, no-checks with and without `--allow-no-checks`, timeout, and `--method merge` / `--keep-branch`. All exit codes as expected.

Two bugs surfaced that way and are fixed: `snapshot="$(pr_json)"` ran the fetch in a subshell so captured stderr never reached the caller (the access-denied case printed the wrong hint), and the no-checks grace period fell through into the merge instead of looping, merging on the first poll.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHArMmVWZaiw2gMcp6QdQs)_